### PR TITLE
Add Dockerfile and make docker target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#       http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+FROM golang:1.6
+
+WORKDIR /go/src/github.com/awslabs/amazon-ecr-credential-helper
+
+COPY . .
+
+CMD make

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ SOURCEDIR=./ecr-login
 SOURCES := $(shell find $(SOURCEDIR) -name '*.go')
 LOCAL_BINARY=bin/local/docker-credential-ecr-login
 
+.PHONY: docker
+docker: Dockerfile
+	docker run --rm -e TARGET_GOOS=$(TARGET_GOOS) -v $(shell pwd)/bin:/go/src/github.com/awslabs/amazon-ecr-credential-helper/bin $(shell docker build -q .)
+
 .PHONY: build
 build: $(LOCAL_BINARY)
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Clone this repository into your existing `GOPATH` under
 `src/github.com/awslabs/amazon-ecr-credential-helper`, then run `make`.  The
 resulting binary can be found in `bin/local/docker-credential-ecr-login`.
 
+Or if you already have Docker environment, just clone this repository anywhere
+and run `make docker`. This command builds the binary by Go inside docker container and
+output it to local directory. With `TARGET_GOOS` environment variable, you can also
+cross complie the binary.
+
 ## Troubleshooting
 
 Logs from the Amazon ECR Docker Credential Helper are stored in `~/.ecr/log`.


### PR DESCRIPTION
This PR is for adding a feature to build a binary within a docker container. It is useful if the customer don't want to setup Go environment for building.

Note: If you use a remote Docker Machine, this won't work since the local volume is not mounted to the container directly.