### PR TITLE
Fixes cache token expiry

### DIFF
--- a/ecr-login/api/client_test.go
+++ b/ecr-login/api/client_test.go
@@ -142,6 +142,7 @@ func TestGetAuthConfigGetCacheSuccess(t *testing.T) {
 	authEntry := &cache.AuthEntry{
 		ProxyEndpoint:      testProxyEndpoint,
 		ExpiresAt:          expiresAt,
+		RequestedAt:        time.Now(),
 		AuthorizationToken: authorizationToken,
 	}
 
@@ -188,8 +189,8 @@ func TestGetAuthConfigSuccessInvalidCacheHit(t *testing.T) {
 
 	expiredAuthEntry := &cache.AuthEntry{
 		ProxyEndpoint:      testProxyEndpoint,
-		RequestedAt:        time.Now().Add(-12 * time.Hour),
-		ExpiresAt:          time.Now().Add(-6 * time.Hour),
+		RequestedAt:        time.Now().Add(-13 * time.Hour),
+		ExpiresAt:          time.Now().Add(-1 * time.Hour),
 		AuthorizationToken: authorizationToken,
 	}
 

--- a/ecr-login/cache/credentials.go
+++ b/ecr-login/cache/credentials.go
@@ -32,5 +32,5 @@ type AuthEntry struct {
 // requested window.
 func (authEntry *AuthEntry) IsValid(testTime time.Time) bool {
 	window := authEntry.ExpiresAt.Sub(authEntry.RequestedAt)
-	return authEntry.ExpiresAt.After(testTime.Add(-1 * (window / time.Duration(2))))
+	return authEntry.ExpiresAt.After(testTime.Add(window / time.Duration(2)))
 }

--- a/ecr-login/cache/file_test.go
+++ b/ecr-login/cache/file_test.go
@@ -36,12 +36,17 @@ var testPath = os.TempDir()
 var testFilename = "test.json"
 var testFullFillename = filepath.Join(testPath, testFilename)
 
+
 func TestAuthEntryValid(t *testing.T) {
-	assert.True(t, testAuthEntry.IsValid(time.Now()))
+	assert.True(t, testAuthEntry.IsValid(time.Now().Add(-1 * time.Hour)))
 }
 
-func TestAuthEntryInValid(t *testing.T) {
-	assert.True(t, testAuthEntry.IsValid(time.Now().Add(time.Second)))
+func TestAuthEntryInValidVeryOld(t *testing.T) {
+	assert.False(t, testAuthEntry.IsValid(time.Now().Add(12 * time.Hour)))
+}
+
+func TestAuthEntryInValidHalftime(t *testing.T) {
+	assert.False(t, testAuthEntry.IsValid(time.Now().Add(3 * time.Hour)))
 }
 
 func TestCredentials(t *testing.T) {


### PR DESCRIPTION
After seeing the behaviour in #7, I dug into the cache expiration logic.

With `authEntry.ExpiresAt.After(testTime.Add(-1 * (window / time.Duration(2))))` we did prolong the the validity of the token rather than shortening it by window/2.

