### PR TITLE
Make expiration logic more readable

### DIFF
--- a/ecr-login/api/client_test.go
+++ b/ecr-login/api/client_test.go
@@ -142,6 +142,7 @@ func TestGetAuthConfigGetCacheSuccess(t *testing.T) {
 	authEntry := &cache.AuthEntry{
 		ProxyEndpoint:      testProxyEndpoint,
 		ExpiresAt:          expiresAt,
+		RequestedAt:        time.Now(),
 		AuthorizationToken: authorizationToken,
 	}
 

--- a/ecr-login/cache/credentials.go
+++ b/ecr-login/cache/credentials.go
@@ -31,6 +31,7 @@ type AuthEntry struct {
 // Checks if AuthEntry is still valid at testTime. AuthEntries expire at 1/2 of their original
 // requested window.
 func (authEntry *AuthEntry) IsValid(testTime time.Time) bool {
-	window := authEntry.ExpiresAt.Sub(authEntry.RequestedAt)
-	return authEntry.ExpiresAt.After(testTime.Add(-1 * (window / time.Duration(2))))
+	validWindow := authEntry.ExpiresAt.Sub(authEntry.RequestedAt)
+	refreshTime := authEntry.ExpiresAt.Add(-1 * validWindow / time.Duration(2))
+	return testTime.Before(refreshTime)
 }

--- a/ecr-login/cache/credentials_test.go
+++ b/ecr-login/cache/credentials_test.go
@@ -1,0 +1,63 @@
+// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValid_NewEntry(t *testing.T) {
+	authEntry := &AuthEntry{
+		RequestedAt: time.Now(),
+		ExpiresAt:   time.Now().Add(12 * time.Hour),
+	}
+	assert.True(t, authEntry.IsValid(time.Now()))
+}
+
+func TestIsValid_OldEntry(t *testing.T) {
+	authEntry := &AuthEntry{
+		RequestedAt: time.Now().Add(-12 * time.Hour),
+		ExpiresAt:   time.Now(),
+	}
+	assert.False(t, authEntry.IsValid(time.Now()))
+}
+
+func TestIsValid_BeforeRefreshTime(t *testing.T) {
+	now := time.Now()
+	authEntry := &AuthEntry{
+		RequestedAt: now.Add(-6 * time.Hour),
+		ExpiresAt:   now.Add(6 * time.Hour),
+	}
+	assert.True(t, authEntry.IsValid(now.Add(-1*time.Second)))
+}
+
+func TestIsValid_AtRefreshTime(t *testing.T) {
+	now := time.Now()
+	authEntry := &AuthEntry{
+		RequestedAt: now.Add(-6 * time.Hour),
+		ExpiresAt:   now.Add(6 * time.Hour),
+	}
+	assert.False(t, authEntry.IsValid(now))
+}
+
+func TestIsValid_AfterRefreshTime(t *testing.T) {
+	now := time.Now()
+	authEntry := &AuthEntry{
+		RequestedAt: now.Add(-6 * time.Hour),
+		ExpiresAt:   now.Add(6 * time.Hour),
+	}
+	assert.False(t, authEntry.IsValid(now.Add(time.Second)))
+}

--- a/ecr-login/cache/file_test.go
+++ b/ecr-login/cache/file_test.go
@@ -24,8 +24,8 @@ import (
 
 var testAuthEntry = AuthEntry{
 	AuthorizationToken: "testToken",
-	RequestedAt:        time.Now().Add(-6 * time.Hour),
-	ExpiresAt:          time.Now().Add(6 * time.Hour),
+	RequestedAt:        time.Now().Add(-5 * time.Hour),
+	ExpiresAt:          time.Now().Add(7 * time.Hour),
 	ProxyEndpoint:      "testEndpoint",
 }
 


### PR DESCRIPTION
Fixes #7

This carries #8 from @f-barth and attempts to make the logic more readable.

r? @sentientmonkey 