### PR TITLE
TARGET_GOARCH for cross-architecture compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,11 @@ LOCAL_BINARY=bin/local/docker-credential-ecr-login
 
 .PHONY: docker
 docker: Dockerfile
-	docker run --rm -e TARGET_GOOS=$(TARGET_GOOS) -v $(shell pwd)/bin:/go/src/github.com/awslabs/amazon-ecr-credential-helper/bin $(shell docker build -q .)
+	docker run --rm \
+	-e TARGET_GOOS=$(TARGET_GOOS) \
+	-e TARGET_GOARCH=$(TARGET_GOARCH) \
+	-v $(shell pwd)/bin:/go/src/github.com/awslabs/amazon-ecr-credential-helper/bin \
+	$(shell docker build -q .)
 
 .PHONY: build
 build: $(LOCAL_BINARY)

--- a/scripts/build_binary.sh
+++ b/scripts/build_binary.sh
@@ -30,4 +30,4 @@ mkdir -p $1
 
 cd "${ROOT}"
 
-GOOS=$TARGET_GOOS CGO_ENABLED=0 go build -installsuffix cgo -a -ldflags '-s' -o $1/docker-credential-ecr-login ./ecr-login/cmd/
+GOOS=$TARGET_GOOS GOARCH=$TARGET_GOARCH CGO_ENABLED=0 go build -installsuffix cgo -a -ldflags '-s' -o $1/docker-credential-ecr-login ./ecr-login/cmd/


### PR DESCRIPTION
https://github.com/awslabs/amazon-ecr-credential-helper/issues/12

Cross-architecture compilation with `make docker TARGET_GOARCH=arm`.

```
$ make
Built ecr-login
$ file bin/local/docker-credential-ecr-login 
bin/local/docker-credential-ecr-login: ELF 64-bit LSB  executable, x86-64, version 1 (SYSV), statically linked, stripped
$ make docker TARGET_GOARCH=arm
Built ecr-login
$ file bin/local/docker-credential-ecr-login 
bin/local/docker-credential-ecr-login: ELF 32-bit LSB  executable, ARM, EABI5 version 1 (SYSV), statically linked, stripped
```