### PR TITLE
gogenerate: Exclude vendored go:generate lines

### DIFF
--- a/scripts/gogenerate
+++ b/scripts/gogenerate
@@ -20,4 +20,4 @@ cd "${ROOT}"
 
 source ./scripts/shared_env
 
-go generate -x ./ecr-login/...
+go generate -x $(go list ./ecr-login/... | grep -v '/vendor/')


### PR DESCRIPTION
This excludes vendored go:generate lines from being executed by `make gogenerate`.