### PR TITLE
Updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,18 @@ in the *AWS Command Line Interface User Guide*.
 The credentials must have a policy applied that
 [allows access to Amazon ECR](http://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr_managed_policies.html).
 
-## Installation
+## Building and Setup
+To build the Amazon ECR Docker Credential Helper, you must have Go 1.5 or greater, and you must have `git`
+and `make` installed on your system.
+
+Clone this repository into your existing `GOPATH` under
+`src/github.com/awslabs/amazon-ecr-credential-helper`, then run `make`.  The
+resulting binary can be found in `bin/local/docker-credential-ecr-login`.
+
+Or if you already have Docker environment, just clone this repository anywhere
+and run `make docker`. This command builds the binary by Go inside docker container and
+output it to local directory. With `TARGET_GOOS` environment variable, you can also
+cross compile the binary.
 
 Place the `docker-credential-ecr-login` binary on your `PATH` and set the contents
 of your `~/.docker/config.json` file to be:
@@ -45,20 +56,6 @@ of your `~/.docker/config.json` file to be:
 `docker push 123457689012.dkr.ecr.us-west-2.amazonaws.com/my-repository:my-tag`
 
 There is no need to use `docker login` or `docker logout`.
-
-## Building
-
-To build the Amazon ECR Docker Credential Helper, you must have Go 1.5 or
-greater, and you must have `git` and `make` installed on your system.
-
-Clone this repository into your existing `GOPATH` under
-`src/github.com/awslabs/amazon-ecr-credential-helper`, then run `make`.  The
-resulting binary can be found in `bin/local/docker-credential-ecr-login`.
-
-Or if you already have Docker environment, just clone this repository anywhere
-and run `make docker`. This command builds the binary by Go inside docker container and
-output it to local directory. With `TARGET_GOOS` environment variable, you can also
-cross compile the binary.
 
 ## Troubleshooting
 


### PR DESCRIPTION
I found the current information architecture of the README to be a little counter intuitive.

Since the README is in English and English reads from the top down, it makes sense to place the steps in order. Currently the installation steps come first, but they don't make sense unless one has already read the building steps, which come after.

I went ahead and merged the two sections and renamed it to "Building and Setup" because the user has build it themselves, not install it.

If/When the binary is published somwehere easily pulled down with a package manager, then it would be good to add a Installation section.