### PR TITLE
Make this reusable for amazon-ecs-cli

### DIFF
--- a/ecr-login/api/client_test.go
+++ b/ecr-login/api/client_test.go
@@ -81,10 +81,11 @@ func TestGetAuthConfigSuccess(t *testing.T) {
 			compareAuthEntry(t, actual, authEntry)
 		})
 
-	username, password, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
+	auth, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
 	assert.Nil(t, err)
-	assert.Equal(t, username, expectedUsername)
-	assert.Equal(t, password, expectedPassword)
+	assert.Equal(t, auth.Username, expectedUsername)
+	assert.Equal(t, auth.Password, expectedPassword)
+	assert.Equal(t, auth.ProxyEndpoint, testProxyEndpoint)
 }
 
 func TestGetAuthConfigNoMatchAuthorizationToken(t *testing.T) {
@@ -117,11 +118,9 @@ func TestGetAuthConfigNoMatchAuthorizationToken(t *testing.T) {
 
 	credentialCache.EXPECT().Get(registryID).Return(nil)
 
-	username, password, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
+	auth, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
 	assert.NotNil(t, err)
-	t.Log(err)
-	assert.Empty(t, username)
-	assert.Empty(t, password)
+	assert.Nil(t, auth)
 }
 
 func TestGetAuthConfigGetCacheSuccess(t *testing.T) {
@@ -148,10 +147,11 @@ func TestGetAuthConfigGetCacheSuccess(t *testing.T) {
 
 	credentialCache.EXPECT().Get(registryID).Return(authEntry)
 
-	username, password, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
+	auth, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
 	assert.Nil(t, err)
-	assert.Equal(t, username, expectedUsername)
-	assert.Equal(t, password, expectedPassword)
+	assert.Equal(t, auth.Username, expectedUsername)
+	assert.Equal(t, auth.Password, expectedPassword)
+	assert.Equal(t, auth.ProxyEndpoint, testProxyEndpoint)
 }
 
 func TestGetAuthConfigSuccessInvalidCacheHit(t *testing.T) {
@@ -207,10 +207,11 @@ func TestGetAuthConfigSuccessInvalidCacheHit(t *testing.T) {
 			compareAuthEntry(t, actual, authEntry)
 		})
 
-	username, password, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
+	auth, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
 	assert.Nil(t, err)
-	assert.Equal(t, username, expectedUsername)
-	assert.Equal(t, password, expectedPassword)
+	assert.Equal(t, auth.Username, expectedUsername)
+	assert.Equal(t, auth.Password, expectedPassword)
+	assert.Equal(t, auth.ProxyEndpoint, testProxyEndpoint)
 }
 
 func TestGetAuthConfigBadBase64(t *testing.T) {
@@ -243,11 +244,10 @@ func TestGetAuthConfigBadBase64(t *testing.T) {
 
 	credentialCache.EXPECT().Get(registryID).Return(nil)
 
-	username, password, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
+	auth, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
 	assert.NotNil(t, err)
 	t.Log(err)
-	assert.Empty(t, username)
-	assert.Empty(t, password)
+	assert.Nil(t, auth)
 }
 
 func TestGetAuthConfigMissingResponse(t *testing.T) {
@@ -273,11 +273,10 @@ func TestGetAuthConfigMissingResponse(t *testing.T) {
 
 	credentialCache.EXPECT().Get(registryID).Return(nil)
 
-	username, password, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
+	auth, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
 	assert.NotNil(t, err)
 	t.Log(err)
-	assert.Empty(t, username)
-	assert.Empty(t, password)
+	assert.Nil(t, auth)
 }
 
 func TestGetAuthConfigECRError(t *testing.T) {
@@ -303,11 +302,10 @@ func TestGetAuthConfigECRError(t *testing.T) {
 
 	credentialCache.EXPECT().Get(registryID).Return(nil)
 
-	username, password, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
+	auth, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
 	assert.NotNil(t, err)
 	t.Log(err)
-	assert.Empty(t, username)
-	assert.Empty(t, password)
+	assert.Nil(t, auth)
 }
 
 func TestGetAuthConfigSuccessInvalidCacheHitFallback(t *testing.T) {
@@ -343,10 +341,11 @@ func TestGetAuthConfigSuccessInvalidCacheHitFallback(t *testing.T) {
 
 	credentialCache.EXPECT().Get(registryID).Return(expiredAuthEntry)
 
-	username, password, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
+	auth, err := client.GetCredentials(registryID, proxyEndpoint+"/myimage")
 	assert.Nil(t, err)
-	assert.Equal(t, username, expectedUsername)
-	assert.Equal(t, password, expectedPassword)
+	assert.Equal(t, auth.Username, expectedUsername)
+	assert.Equal(t, auth.Password, expectedPassword)
+	assert.Equal(t, auth.ProxyEndpoint, testProxyEndpoint)
 }
 
 func compareAuthEntry(t *testing.T, actual *cache.AuthEntry, expected *cache.AuthEntry) {

--- a/ecr-login/api/factory.go
+++ b/ecr-login/api/factory.go
@@ -31,15 +31,23 @@ import (
 
 type ClientFactory interface {
 	NewClient(region string) Client
+	NewClientWithAWSConfig(awsSession *session.Session, awsConfig *aws.Config) Client
 }
 type DefaultClientFactory struct{}
 
-func (defaultClientFactory DefaultClientFactory) NewClient(region string) Client {
+// NewClientWithRegion uses the region to create the client
+func (defaultClientFactory DefaultClientFactory) NewClientWithRegion(region string) Client {
 	awsSession := session.New()
+	awsConfig := &aws.Config{Region: aws.String(region)}
 
+	return defaultClientFactory.NewClient(awsSession, awsConfig)
+}
+
+// NewClient Create new client with AWS Config
+func (defaultClientFactory DefaultClientFactory) NewClient(awsSession *session.Session, awsConfig *aws.Config) Client {
 	return &defaultClient{
-		ecrClient:       ecr.New(awsSession, &aws.Config{Region: aws.String(region)}),
-		credentialCache: defaultClientFactory.buildCredentialsCache(awsSession, region),
+		ecrClient:       ecr.New(awsSession, awsConfig),
+		credentialCache: defaultClientFactory.buildCredentialsCache(awsSession, aws.StringValue(awsConfig.Region)),
 	}
 }
 

--- a/ecr-login/api/factory.go
+++ b/ecr-login/api/factory.go
@@ -31,12 +31,12 @@ import (
 
 type ClientFactory interface {
 	NewClient(awsSession *session.Session, awsConfig *aws.Config) Client
-	NewClientWithRegion(region string) Client
+	NewClientFromRegion(region string) Client
 }
 type DefaultClientFactory struct{}
 
-// NewClientWithRegion uses the region to create the client
-func (defaultClientFactory DefaultClientFactory) NewClientWithRegion(region string) Client {
+// NewClientFromRegion uses the region to create the client
+func (defaultClientFactory DefaultClientFactory) NewClientFromRegion(region string) Client {
 	awsSession := session.New()
 	awsConfig := &aws.Config{Region: aws.String(region)}
 

--- a/ecr-login/api/factory.go
+++ b/ecr-login/api/factory.go
@@ -30,8 +30,8 @@ import (
 )
 
 type ClientFactory interface {
-	NewClient(region string) Client
-	NewClientWithAWSConfig(awsSession *session.Session, awsConfig *aws.Config) Client
+	NewClient(awsSession *session.Session, awsConfig *aws.Config) Client
+	NewClientWithRegion(region string) Client
 }
 type DefaultClientFactory struct{}
 

--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -55,11 +55,11 @@ func (self ECRHelper) Get(serverURL string) (string, string, error) {
 	registry := matches[1]
 	region := matches[2]
 	log.Debugf("Retrieving credentials for %s in %s (%s)", registry, region, serverURL)
-	client := self.ClientFactory.NewClient(region)
-	user, pass, _, err := client.GetCredentials(registry, serverURL)
+	client := self.ClientFactory.NewClientWithRegion(region)
+	auth, err := client.GetCredentials(registry, serverURL)
 	if err != nil {
 		log.Errorf("Error retrieving credentials: %v", err)
 		return "", "", credentials.ErrCredentialsNotFound
 	}
-	return user, pass, nil
+	return auth.Username, auth.Password, nil
 }

--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -56,7 +56,7 @@ func (self ECRHelper) Get(serverURL string) (string, string, error) {
 	region := matches[2]
 	log.Debugf("Retrieving credentials for %s in %s (%s)", registry, region, serverURL)
 	client := self.ClientFactory.NewClient(region)
-	user, pass, err := client.GetCredentials(registry, serverURL)
+	user, pass, _, err := client.GetCredentials(registry, serverURL)
 	if err != nil {
 		log.Errorf("Error retrieving credentials: %v", err)
 		return "", "", credentials.ErrCredentialsNotFound

--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -55,7 +55,7 @@ func (self ECRHelper) Get(serverURL string) (string, string, error) {
 	registry := matches[1]
 	region := matches[2]
 	log.Debugf("Retrieving credentials for %s in %s (%s)", registry, region, serverURL)
-	client := self.ClientFactory.NewClientWithRegion(region)
+	client := self.ClientFactory.NewClientFromRegion(region)
 	auth, err := client.GetCredentials(registry, serverURL)
 	if err != nil {
 		log.Errorf("Error retrieving credentials: %v", err)

--- a/ecr-login/ecr_test.go
+++ b/ecr-login/ecr_test.go
@@ -26,7 +26,8 @@ import (
 const (
 	region           = "my-region-1"
 	registryID       = "123456789012"
-	image            = registryID + ".dkr.ecr." + region + ".amazonaws.com/my-image"
+	proxyEndpoint    = registryID + ".dkr.ecr." + region + ".amazonaws.com"
+	image            = proxyEndpoint + "/my-image"
 	expectedUsername = "username"
 	expectedPassword = "password"
 )
@@ -42,7 +43,7 @@ func TestGetSuccess(t *testing.T) {
 	}
 
 	factory.EXPECT().NewClient(region).Return(client)
-	client.EXPECT().GetCredentials(registryID, image).Return(expectedUsername, expectedPassword, nil)
+	client.EXPECT().GetCredentials(registryID, image).Return(expectedUsername, expectedPassword, proxyEndpoint, nil)
 
 	username, password, err := helper.Get(image)
 	assert.Nil(t, err)
@@ -61,7 +62,7 @@ func TestGetError(t *testing.T) {
 	}
 
 	factory.EXPECT().NewClient(region).Return(client)
-	client.EXPECT().GetCredentials(registryID, image).Return("", "", errors.New("test error"))
+	client.EXPECT().GetCredentials(registryID, image).Return("", "", "", errors.New("test error"))
 
 	username, password, err := helper.Get(image)
 	assert.Equal(t, credentials.ErrCredentialsNotFound, err)

--- a/ecr-login/ecr_test.go
+++ b/ecr-login/ecr_test.go
@@ -43,7 +43,7 @@ func TestGetSuccess(t *testing.T) {
 		ClientFactory: factory,
 	}
 
-	factory.EXPECT().NewClientWithRegion(region).Return(client)
+	factory.EXPECT().NewClientFromRegion(region).Return(client)
 	client.EXPECT().GetCredentials(registryID, image).Return(&ecr.Auth{
 		Username:      expectedUsername,
 		Password:      expectedPassword,
@@ -66,7 +66,7 @@ func TestGetError(t *testing.T) {
 		ClientFactory: factory,
 	}
 
-	factory.EXPECT().NewClientWithRegion(region).Return(client)
+	factory.EXPECT().NewClientFromRegion(region).Return(client)
 	client.EXPECT().GetCredentials(registryID, image).Return(nil, errors.New("test error"))
 
 	username, password, err := helper.Get(image)

--- a/ecr-login/mocks/ecr_mocks.go
+++ b/ecr-login/mocks/ecr_mocks.go
@@ -54,14 +54,14 @@ func (_mr *_MockClientFactoryRecorder) NewClient(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewClient", arg0, arg1)
 }
 
-func (_m *MockClientFactory) NewClientWithRegion(_param0 string) api.Client {
-	ret := _m.ctrl.Call(_m, "NewClientWithRegion", _param0)
+func (_m *MockClientFactory) NewClientFromRegion(_param0 string) api.Client {
+	ret := _m.ctrl.Call(_m, "NewClientFromRegion", _param0)
 	ret0, _ := ret[0].(api.Client)
 	return ret0
 }
 
-func (_mr *_MockClientFactoryRecorder) NewClientWithRegion(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewClientWithRegion", arg0)
+func (_mr *_MockClientFactoryRecorder) NewClientFromRegion(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewClientFromRegion", arg0)
 }
 
 // Mock of Client interface

--- a/ecr-login/mocks/ecr_mocks.go
+++ b/ecr-login/mocks/ecr_mocks.go
@@ -44,24 +44,24 @@ func (_m *MockClientFactory) EXPECT() *_MockClientFactoryRecorder {
 	return _m.recorder
 }
 
-func (_m *MockClientFactory) NewClient(_param0 string) api.Client {
-	ret := _m.ctrl.Call(_m, "NewClient", _param0)
+func (_m *MockClientFactory) NewClient(_param0 *session.Session, _param1 *aws.Config) api.Client {
+	ret := _m.ctrl.Call(_m, "NewClient", _param0, _param1)
 	ret0, _ := ret[0].(api.Client)
 	return ret0
 }
 
-func (_mr *_MockClientFactoryRecorder) NewClient(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewClient", arg0)
+func (_mr *_MockClientFactoryRecorder) NewClient(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewClient", arg0, arg1)
 }
 
-func (_m *MockClientFactory) NewClientWithAWSConfig(_param0 *session.Session, _param1 *aws.Config) api.Client {
-	ret := _m.ctrl.Call(_m, "NewClientWithAWSConfig", _param0, _param1)
+func (_m *MockClientFactory) NewClientWithRegion(_param0 string) api.Client {
+	ret := _m.ctrl.Call(_m, "NewClientWithRegion", _param0)
 	ret0, _ := ret[0].(api.Client)
 	return ret0
 }
 
-func (_mr *_MockClientFactoryRecorder) NewClientWithAWSConfig(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewClientWithAWSConfig", arg0, arg1)
+func (_mr *_MockClientFactoryRecorder) NewClientWithRegion(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewClientWithRegion", arg0)
 }
 
 // Mock of Client interface

--- a/ecr-login/mocks/ecr_mocks.go
+++ b/ecr-login/mocks/ecr_mocks.go
@@ -17,6 +17,8 @@
 package mock_api
 
 import (
+	aws "github.com/aws/aws-sdk-go/aws"
+	session "github.com/aws/aws-sdk-go/aws/session"
 	api "github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -52,6 +54,16 @@ func (_mr *_MockClientFactoryRecorder) NewClient(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewClient", arg0)
 }
 
+func (_m *MockClientFactory) NewClientWithAWSConfig(_param0 *session.Session, _param1 *aws.Config) api.Client {
+	ret := _m.ctrl.Call(_m, "NewClientWithAWSConfig", _param0, _param1)
+	ret0, _ := ret[0].(api.Client)
+	return ret0
+}
+
+func (_mr *_MockClientFactoryRecorder) NewClientWithAWSConfig(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewClientWithAWSConfig", arg0, arg1)
+}
+
 // Mock of Client interface
 type MockClient struct {
 	ctrl     *gomock.Controller
@@ -73,12 +85,11 @@ func (_m *MockClient) EXPECT() *_MockClientRecorder {
 	return _m.recorder
 }
 
-func (_m *MockClient) GetCredentials(_param0 string, _param1 string) (string, string, error) {
+func (_m *MockClient) GetCredentials(_param0 string, _param1 string) (*api.Auth, error) {
 	ret := _m.ctrl.Call(_m, "GetCredentials", _param0, _param1)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret0, _ := ret[0].(*api.Auth)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockClientRecorder) GetCredentials(arg0, arg1 interface{}) *gomock.Call {

--- a/scripts/generate/mockgen.sh
+++ b/scripts/generate/mockgen.sh
@@ -19,6 +19,7 @@ set -e
 package=${1?Must provide package}
 interfaces=${2?Must provide interface names}
 outputfile=${3?Must provide an output file}
+PROJECT_VENDOR="github.com/awslabs/amazon-ecr-credential-helper/ecr-login/vendor/"
 
 export PATH="${GOPATH//://bin:}/bin:$PATH"
 
@@ -43,4 +44,4 @@ EOF
 
 mkdir -p $(dirname ${outputfile})
 
-echo "$data" | goimports > "${outputfile}"
+echo "$data" | sed -e "s|${PROJECT_VENDOR}||" | goimports > "${outputfile}"


### PR DESCRIPTION
* GetCredential returns proxyEndpoint
* NewClient uses AWSConfig