### PR TITLE
Implement helper list

### DIFF
--- a/ecr-login/Godeps/Godeps.json
+++ b/ecr-login/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/awslabs/amazon-ecr-credential-helper/ecr-login",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v75",
+	"GodepVersion": "v79",
 	"Packages": [
 		"./..."
 	],
@@ -117,8 +117,8 @@
 		},
 		{
 			"ImportPath": "github.com/docker/docker-credential-helpers/credentials",
-			"Comment": "v0.2.0-8-g00703eb",
-			"Rev": "00703eb6dbc8783c9093cad8202ef246a07d20ce"
+			"Comment": "v0.4.1",
+			"Rev": "b7c53e02cd1a9a01500a58f22d83c6e964bc59db"
 		},
 		{
 			"ImportPath": "github.com/go-ini/ini",

--- a/ecr-login/api/factory.go
+++ b/ecr-login/api/factory.go
@@ -14,26 +14,24 @@
 package api
 
 import (
-	"crypto/md5"
-	"encoding/base64"
-	"fmt"
-	"os"
-
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cache"
-	"github.com/mitchellh/go-homedir"
-
-	log "github.com/cihub/seelog"
 )
 
 type ClientFactory interface {
 	NewClient(awsSession *session.Session, awsConfig *aws.Config) Client
 	NewClientFromRegion(region string) Client
+	NewClientWithDefaults() Client
 }
 type DefaultClientFactory struct{}
+
+// NewClientWithDefaults creates the client and defaults region
+func (defaultClientFactory DefaultClientFactory) NewClientWithDefaults() Client {
+	awsSession := session.New()
+	return defaultClientFactory.NewClient(awsSession, awsSession.Config)
+}
 
 // NewClientFromRegion uses the region to create the client
 func (defaultClientFactory DefaultClientFactory) NewClientFromRegion(region string) Client {
@@ -47,44 +45,6 @@ func (defaultClientFactory DefaultClientFactory) NewClientFromRegion(region stri
 func (defaultClientFactory DefaultClientFactory) NewClient(awsSession *session.Session, awsConfig *aws.Config) Client {
 	return &defaultClient{
 		ecrClient:       ecr.New(awsSession, awsConfig),
-		credentialCache: defaultClientFactory.buildCredentialsCache(awsSession, aws.StringValue(awsConfig.Region)),
+		credentialCache: cache.BuildCredentialsCache(awsSession, aws.StringValue(awsConfig.Region)),
 	}
-}
-
-func (defaultClientFactory DefaultClientFactory) buildCredentialsCache(awsSession *session.Session, region string) cache.CredentialsCache {
-	if os.Getenv("AWS_ECR_DISABLE_CACHE") != "" {
-		log.Debug("Cache disabled due to AWS_ECR_DISABLE_CACHE")
-		return cache.NewNullCredentialsCache()
-	}
-
-	cacheDir, err := homedir.Expand("~/.ecr")
-	if err != nil {
-		log.Debugf("Could expand cache path: %s", err)
-		log.Debug("Disabling cache")
-		return cache.NewNullCredentialsCache()
-	}
-
-	cacheFilename := "cache.json"
-
-	credentials, err := awsSession.Config.Credentials.Get()
-	if err != nil {
-		log.Debugf("Could fetch credentials for cache prefix: %s", err)
-		log.Debug("Disabling cache")
-		return cache.NewNullCredentialsCache()
-	}
-
-	return cache.NewFileCredentialsCache(cacheDir, cacheFilename, defaultClientFactory.credentialsCachePrefix(region, &credentials))
-}
-
-// Determine a key prefix for a credentials cache. Because auth tokens are scoped to an account and region, rely on provided
-// region, as well as hash of the access key.
-func (defaultClientFactory DefaultClientFactory) credentialsCachePrefix(region string, credentials *credentials.Value) string {
-	return fmt.Sprintf("%s-%s-", region, checksum(credentials.AccessKeyID))
-}
-
-// Base64 encodes an MD5 checksum. Relied on for uniqueness, and not for cryptographic security.
-func checksum(text string) string {
-	hasher := md5.New()
-	data := hasher.Sum([]byte(text))
-	return base64.StdEncoding.EncodeToString(data)
 }

--- a/ecr-login/cache/build.go
+++ b/ecr-login/cache/build.go
@@ -1,0 +1,64 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cache
+
+import (
+	"crypto/md5"
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	log "github.com/cihub/seelog"
+	homedir "github.com/mitchellh/go-homedir"
+)
+
+func BuildCredentialsCache(awsSession *session.Session, region string) CredentialsCache {
+	if os.Getenv("AWS_ECR_DISABLE_CACHE") != "" {
+		log.Debug("Cache disabled due to AWS_ECR_DISABLE_CACHE")
+		return NewNullCredentialsCache()
+	}
+
+	cacheDir, err := homedir.Expand("~/.ecr")
+	if err != nil {
+		log.Debugf("Could not expand cache path: %s", err)
+		log.Debug("Disabling cache")
+		return NewNullCredentialsCache()
+	}
+
+	cacheFilename := "cache.json"
+
+	credentials, err := awsSession.Config.Credentials.Get()
+	if err != nil {
+		log.Debugf("Could not fetch credentials for cache prefix: %s", err)
+		log.Debug("Disabling cache")
+		return NewNullCredentialsCache()
+	}
+
+	return NewFileCredentialsCache(cacheDir, cacheFilename, credentialsCachePrefix(region, &credentials))
+}
+
+// Determine a key prefix for a credentials cache. Because auth tokens are scoped to an account and region, rely on provided
+// region, as well as hash of the access key.
+func credentialsCachePrefix(region string, credentials *credentials.Value) string {
+	return fmt.Sprintf("%s-%s-", region, checksum(credentials.AccessKeyID))
+}
+
+// Base64 encodes an MD5 checksum. Relied on for uniqueness, and not for cryptographic security.
+func checksum(text string) string {
+	hasher := md5.New()
+	data := hasher.Sum([]byte(text))
+	return base64.StdEncoding.EncodeToString(data)
+}

--- a/ecr-login/cache/build_test.go
+++ b/ecr-login/cache/build_test.go
@@ -1,0 +1,76 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cache
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awscredentials "github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testRegion        = "test-region"
+	testCacheFilename = "cache.json"
+	testAccessKey     = "accessKey"
+	testSecretKey     = "secretKey"
+	testToken         = "token"
+	// base64 MD5 sum of Credentials struct
+	testCredentialHash = "YWNjZXNzS2V51B2M2Y8AsgTpgAmY7PhCfg=="
+)
+
+func TestFactoryBuildFileCache(t *testing.T) {
+	awsSession, _ := session.NewSession(&aws.Config{
+		Region:      aws.String(testRegion),
+		Credentials: awscredentials.NewStaticCredentials(testAccessKey, testSecretKey, testToken),
+	})
+
+	cache := BuildCredentialsCache(awsSession, testRegion)
+	assert.NotNil(t, cache)
+
+	fileCache, ok := cache.(*fileCredentialCache)
+
+	assert.True(t, ok, "built cache is not a fileCredentialsCache")
+	assert.Equal(t, fileCache.cachePrefixKey, fmt.Sprintf("%s-%s-", testRegion, testCredentialHash))
+	assert.Equal(t, fileCache.filename, testCacheFilename)
+}
+
+func TestFactoryBuildNullCacheWithoutCredentials(t *testing.T) {
+	awsSession, _ := session.NewSession(&aws.Config{
+		Region:      aws.String(testRegion),
+		Credentials: awscredentials.AnonymousCredentials,
+	})
+
+	cache := BuildCredentialsCache(awsSession, testRegion)
+	assert.NotNil(t, cache)
+
+	_, ok := cache.(*nullCredentialsCache)
+	assert.True(t, ok, "built cache is a nullCredentialsCache")
+}
+
+func TestFactoryBuildNullCache(t *testing.T) {
+	os.Setenv("AWS_ECR_DISABLE_CACHE", "1")
+	defer os.Setenv("AWS_ECR_DISABLE_CACHE", "1")
+
+	awsSession, _ := session.NewSession(&aws.Config{Region: aws.String(testRegion)})
+
+	cache := BuildCredentialsCache(awsSession, testRegion)
+	assert.NotNil(t, cache)
+	_, ok := cache.(*nullCredentialsCache)
+	assert.True(t, ok, "built cache is a nullCredentialsCache")
+}

--- a/ecr-login/cache/credentials.go
+++ b/ecr-login/cache/credentials.go
@@ -18,6 +18,7 @@ import "time"
 type CredentialsCache interface {
 	Get(registry string) *AuthEntry
 	Set(registry string, entry *AuthEntry)
+	List() []*AuthEntry
 	Clear()
 }
 

--- a/ecr-login/cache/file_test.go
+++ b/ecr-login/cache/file_test.go
@@ -55,6 +55,11 @@ func TestCredentials(t *testing.T) {
 	assert.WithinDuration(t, testAuthEntry.RequestedAt, entry.RequestedAt, 1*time.Second)
 	assert.WithinDuration(t, testAuthEntry.ExpiresAt, entry.ExpiresAt, 1*time.Second)
 
+	entries := credentialCache.List()
+	assert.NotEmpty(t, entries)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, entry, entries[0])
+
 	credentialCache.Clear()
 
 	entry = credentialCache.Get(testRegistryName)

--- a/ecr-login/cache/mocks/cache_mocks.go
+++ b/ecr-login/cache/mocks/cache_mocks.go
@@ -60,6 +60,16 @@ func (_mr *_MockCredentialsCacheRecorder) Get(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0)
 }
 
+func (_m *MockCredentialsCache) List() []*cache.AuthEntry {
+	ret := _m.ctrl.Call(_m, "List")
+	ret0, _ := ret[0].([]*cache.AuthEntry)
+	return ret0
+}
+
+func (_mr *_MockCredentialsCacheRecorder) List() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "List")
+}
+
 func (_m *MockCredentialsCache) Set(_param0 string, _param1 *cache.AuthEntry) {
 	_m.ctrl.Call(_m, "Set", _param0, _param1)
 }

--- a/ecr-login/cache/null.go
+++ b/ecr-login/cache/null.go
@@ -26,5 +26,9 @@ func (nullCache *nullCredentialsCache) Get(registry string) *AuthEntry {
 func (nullCache *nullCredentialsCache) Set(registry string, entry *AuthEntry) {
 }
 
+func (nullCache *nullCredentialsCache) List() []*AuthEntry {
+	return []*AuthEntry{}
+}
+
 func (nullCache *nullCredentialsCache) Clear() {
 }

--- a/ecr-login/cache/null_test.go
+++ b/ecr-login/cache/null_test.go
@@ -31,4 +31,7 @@ func TestNullCache(t *testing.T) {
 	assert.Nil(t, entry)
 
 	credentialCache.Clear()
+
+	entries := credentialCache.List()
+	assert.Empty(t, entries)
 }

--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -31,6 +31,9 @@ type ECRHelper struct {
 	ClientFactory api.ClientFactory
 }
 
+// ensure ECRHelper adheres to the credentials.Helper interface
+var _ credentials.Helper = (*ECRHelper)(nil)
+
 func (ECRHelper) Add(creds *credentials.Credentials) error {
 	// This does not seem to get called
 	return notImplemented
@@ -46,10 +49,10 @@ func (self ECRHelper) Get(serverURL string) (string, string, error) {
 	matches := ecrPattern.FindStringSubmatch(serverURL)
 	if len(matches) == 0 {
 		log.Error(programName + " can only be used with Amazon EC2 Container Registry.")
-		return "", "", credentials.ErrCredentialsNotFound
+		return "", "", credentials.NewErrCredentialsNotFound()
 	} else if len(matches) < 3 {
 		log.Error(serverURL + "is not a valid repository URI for Amazon EC2 Container Registry.")
-		return "", "", credentials.ErrCredentialsNotFound
+		return "", "", credentials.NewErrCredentialsNotFound()
 	}
 
 	registry := matches[1]
@@ -59,7 +62,12 @@ func (self ECRHelper) Get(serverURL string) (string, string, error) {
 	auth, err := client.GetCredentials(registry, serverURL)
 	if err != nil {
 		log.Errorf("Error retrieving credentials: %v", err)
-		return "", "", credentials.ErrCredentialsNotFound
+		return "", "", credentials.NewErrCredentialsNotFound()
 	}
 	return auth.Username, auth.Password, nil
+}
+
+func (self ECRHelper) List() (map[string]string, error) {
+	//TODO implement for docker 1.13 --pull
+	return nil, notImplemented
 }

--- a/ecr-login/ecr_test.go
+++ b/ecr-login/ecr_test.go
@@ -70,7 +70,7 @@ func TestGetError(t *testing.T) {
 	client.EXPECT().GetCredentials(registryID, image).Return(nil, errors.New("test error"))
 
 	username, password, err := helper.Get(image)
-	assert.Equal(t, credentials.ErrCredentialsNotFound, err)
+	assert.True(t, credentials.IsErrCredentialsNotFound(err))
 	assert.Empty(t, username)
 	assert.Empty(t, password)
 }
@@ -79,7 +79,7 @@ func TestGetNoMatch(t *testing.T) {
 	helper := &ECRHelper{}
 
 	username, password, err := helper.Get("not-ecr-server-url")
-	assert.Equal(t, credentials.ErrCredentialsNotFound, err)
+	assert.True(t, credentials.IsErrCredentialsNotFound(err))
 	assert.Empty(t, username)
 	assert.Empty(t, password)
 }

--- a/ecr-login/mocks/ecr_mocks.go
+++ b/ecr-login/mocks/ecr_mocks.go
@@ -64,6 +64,16 @@ func (_mr *_MockClientFactoryRecorder) NewClientFromRegion(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewClientFromRegion", arg0)
 }
 
+func (_m *MockClientFactory) NewClientWithDefaults() api.Client {
+	ret := _m.ctrl.Call(_m, "NewClientWithDefaults")
+	ret0, _ := ret[0].(api.Client)
+	return ret0
+}
+
+func (_mr *_MockClientFactoryRecorder) NewClientWithDefaults() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewClientWithDefaults")
+}
+
 // Mock of Client interface
 type MockClient struct {
 	ctrl     *gomock.Controller
@@ -94,4 +104,15 @@ func (_m *MockClient) GetCredentials(_param0 string, _param1 string) (*api.Auth,
 
 func (_mr *_MockClientRecorder) GetCredentials(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCredentials", arg0, arg1)
+}
+
+func (_m *MockClient) ListCredentials() ([]*api.Auth, error) {
+	ret := _m.ctrl.Call(_m, "ListCredentials")
+	ret0, _ := ret[0].([]*api.Auth)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockClientRecorder) ListCredentials() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListCredentials")
 }

--- a/ecr-login/vendor/github.com/docker/docker-credential-helpers/credentials/credentials.go
+++ b/ecr-login/vendor/github.com/docker/docker-credential-helpers/credentials/credentials.go
@@ -10,6 +10,13 @@ import (
 	"strings"
 )
 
+// Credentials holds the information shared between docker and the credentials store.
+type Credentials struct {
+	ServerURL string
+	Username  string
+	Secret    string
+}
+
 // Serve initializes the credentials helper and parses the action argument.
 // This function is designed to be called from a command line interface.
 // It uses os.Args[1] as the key for the action.
@@ -18,7 +25,7 @@ import (
 func Serve(helper Helper) {
 	var err error
 	if len(os.Args) != 2 {
-		err = fmt.Errorf("Usage: %s <store|get|erase>", os.Args[0])
+		err = fmt.Errorf("Usage: %s <store|get|erase|list>", os.Args[0])
 	}
 
 	if err == nil {
@@ -40,6 +47,8 @@ func HandleCommand(helper Helper, key string, in io.Reader, out io.Writer) error
 		return Get(helper, in, out)
 	case "erase":
 		return Erase(helper, in)
+	case "list":
+		return List(helper, out)
 	}
 	return fmt.Errorf("Unknown credential action `%s`", key)
 }
@@ -119,4 +128,14 @@ func Erase(helper Helper, reader io.Reader) error {
 	serverURL := strings.TrimSpace(buffer.String())
 
 	return helper.Delete(serverURL)
+}
+
+//List returns all the serverURLs of keys in
+//the OS store as a list of strings
+func List(helper Helper, writer io.Writer) error {
+	accts, err := helper.List()
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(writer).Encode(accts)
 }

--- a/ecr-login/vendor/github.com/docker/docker-credential-helpers/credentials/error.go
+++ b/ecr-login/vendor/github.com/docker/docker-credential-helpers/credentials/error.go
@@ -1,0 +1,37 @@
+package credentials
+
+// ErrCredentialsNotFound standarizes the not found error, so every helper returns
+// the same message and docker can handle it properly.
+const errCredentialsNotFoundMessage = "credentials not found in native keychain"
+
+// errCredentialsNotFound represents an error
+// raised when credentials are not in the store.
+type errCredentialsNotFound struct{}
+
+// Error returns the standard error message
+// for when the credentials are not in the store.
+func (errCredentialsNotFound) Error() string {
+	return errCredentialsNotFoundMessage
+}
+
+// NewErrCredentialsNotFound creates a new error
+// for when the credentials are not in the store.
+func NewErrCredentialsNotFound() error {
+	return errCredentialsNotFound{}
+}
+
+// IsErrCredentialsNotFound returns true if the error
+// was caused by not having a set of credentials in a store.
+func IsErrCredentialsNotFound(err error) bool {
+	_, ok := err.(errCredentialsNotFound)
+	return ok
+}
+
+// IsErrCredentialsNotFoundMessage returns true if the error
+// was caused by not having a set of credentials in a store.
+//
+// This function helps to check messages returned by an
+// external program via its standard output.
+func IsErrCredentialsNotFoundMessage(err string) bool {
+	return err == errCredentialsNotFoundMessage
+}

--- a/ecr-login/vendor/github.com/docker/docker-credential-helpers/credentials/helper.go
+++ b/ecr-login/vendor/github.com/docker/docker-credential-helpers/credentials/helper.go
@@ -1,14 +1,5 @@
 package credentials
 
-import "errors"
-
-// Credentials holds the information shared between docker and the credentials store.
-type Credentials struct {
-	ServerURL string
-	Username  string
-	Secret    string
-}
-
 // Helper is the interface a credentials store helper must implement.
 type Helper interface {
 	// Add appends credentials to the store.
@@ -18,8 +9,6 @@ type Helper interface {
 	// Get retrieves credentials from the store.
 	// It returns username and secret as strings.
 	Get(serverURL string) (string, string, error)
+	// List returns the stored serverURLs and their associated usernames.
+	List() (map[string]string, error)
 }
-
-// ErrCredentialsNotFound standarizes the not found error, so every helper returns
-// the same message and docker can handle it properly.
-var ErrCredentialsNotFound = errors.New("credentials not found in native keychain")


### PR DESCRIPTION
Beginning on implementation for the List API to fix #23. This vends the latest docker-credential-helper and fixes the build by providing a notImplemented interface for List.

From looking at the List API implementation, this appears to return all service urls and usernames. We should be able to provide similar functionality by walking the cache file and returning all of the repositories and usernames within the auth tokens. Repositories not already cached will not be returned. Anyone using the null cache will never get any values returned as well. We should also be able to implement Erase, but Add still doesn't really make sense for our use cases.

The major area we'll have to refactor here is that the ClientFactory today is created regionally, and the cache really global. I think the right approach here is to expose the cache up one level higher for access by our helper. Thoughts? @samuelkarp @yinshiua