### PR TITLE
Get default registry's credential when List if cache doesn't exist

### DIFF
--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -44,13 +44,13 @@ func (ECRHelper) Delete(serverURL string) error {
 func (self ECRHelper) Get(serverURL string) (string, string, error) {
 	defer log.Flush()
 
-	_, region, err := api.ExtractRegistryAndRegion(serverURL)
+	registry, err := api.ExtractRegistry(serverURL)
 	if err != nil {
 		log.Errorf("Error parsing the serverURL: %v", err)
 		return "", "", credentials.NewErrCredentialsNotFound()
 	}
 
-	client := self.ClientFactory.NewClientFromRegion(region)
+	client := self.ClientFactory.NewClientFromRegion(registry.Region)
 	auth, err := client.GetCredentials(serverURL)
 	if err != nil {
 		log.Errorf("Error retrieving credentials: %v", err)

--- a/ecr-login/ecr_test.go
+++ b/ecr-login/ecr_test.go
@@ -26,11 +26,9 @@ import (
 )
 
 const (
-	region           = "my-region-1"
-	registryID       = "123456789012"
-	proxyEndpoint    = registryID + ".dkr.ecr." + region + ".amazonaws.com"
+	region           = "us-east-1"
+	proxyEndpoint    = "123456789012" + ".dkr.ecr." + region + ".amazonaws.com"
 	proxyEndpointUrl = "https://" + proxyEndpoint
-	image            = proxyEndpoint + "/my-image"
 	expectedUsername = "username"
 	expectedPassword = "password"
 )
@@ -46,13 +44,13 @@ func TestGetSuccess(t *testing.T) {
 	}
 
 	factory.EXPECT().NewClientFromRegion(region).Return(client)
-	client.EXPECT().GetCredentials(registryID, image).Return(&ecr.Auth{
+	client.EXPECT().GetCredentials(proxyEndpoint).Return(&ecr.Auth{
 		Username:      expectedUsername,
 		Password:      expectedPassword,
-		ProxyEndpoint: proxyEndpoint,
+		ProxyEndpoint: proxyEndpointUrl,
 	}, nil)
 
-	username, password, err := helper.Get(image)
+	username, password, err := helper.Get(proxyEndpoint)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedUsername, username)
 	assert.Equal(t, expectedPassword, password)
@@ -69,9 +67,9 @@ func TestGetError(t *testing.T) {
 	}
 
 	factory.EXPECT().NewClientFromRegion(region).Return(client)
-	client.EXPECT().GetCredentials(registryID, image).Return(nil, errors.New("test error"))
+	client.EXPECT().GetCredentials(proxyEndpoint).Return(nil, errors.New("test error"))
 
-	username, password, err := helper.Get(image)
+	username, password, err := helper.Get(proxyEndpoint)
 	assert.True(t, credentials.IsErrCredentialsNotFound(err))
 	assert.Empty(t, username)
 	assert.Empty(t, password)
@@ -108,7 +106,7 @@ func TestListSuccess(t *testing.T) {
 	serverList, err := helper.List()
 	assert.NoError(t, err)
 	assert.Len(t, serverList, 1)
-	assert.Equal(t, expectedUsername, serverList[proxyEndpoint])
+	assert.Equal(t, expectedUsername, serverList[proxyEndpointUrl])
 }
 
 func TestListFailure(t *testing.T) {

--- a/ecr-login/mocks/ecr_mocks.go
+++ b/ecr-login/mocks/ecr_mocks.go
@@ -106,6 +106,17 @@ func (_mr *_MockClientRecorder) GetCredentials(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCredentials", arg0)
 }
 
+func (_m *MockClient) GetCredentialsByRegistryID(_param0 string) (*api.Auth, error) {
+	ret := _m.ctrl.Call(_m, "GetCredentialsByRegistryID", _param0)
+	ret0, _ := ret[0].(*api.Auth)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockClientRecorder) GetCredentialsByRegistryID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCredentialsByRegistryID", arg0)
+}
+
 func (_m *MockClient) ListCredentials() ([]*api.Auth, error) {
 	ret := _m.ctrl.Call(_m, "ListCredentials")
 	ret0, _ := ret[0].([]*api.Auth)

--- a/ecr-login/mocks/ecr_mocks.go
+++ b/ecr-login/mocks/ecr_mocks.go
@@ -95,15 +95,15 @@ func (_m *MockClient) EXPECT() *_MockClientRecorder {
 	return _m.recorder
 }
 
-func (_m *MockClient) GetCredentials(_param0 string, _param1 string) (*api.Auth, error) {
-	ret := _m.ctrl.Call(_m, "GetCredentials", _param0, _param1)
+func (_m *MockClient) GetCredentials(_param0 string) (*api.Auth, error) {
+	ret := _m.ctrl.Call(_m, "GetCredentials", _param0)
 	ret0, _ := ret[0].(*api.Auth)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockClientRecorder) GetCredentials(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCredentials", arg0, arg1)
+func (_mr *_MockClientRecorder) GetCredentials(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCredentials", arg0)
 }
 
 func (_m *MockClient) ListCredentials() ([]*api.Auth, error) {


### PR DESCRIPTION
This is based upon https://github.com/awslabs/amazon-ecr-credential-helper/pull/26. The purpose is to make `docker build --pull` can still work even cache doesn't exist, hence fully address https://github.com/awslabs/amazon-ecr-credential-helper/issues/23. Basically, in the ListCredentials() function I invoked getAuthorizationToken for default registry if there's no credential cache. It only requires the user has set AWS_REGION environment variable.

Also refactored a bit the code:
- Client.GetCredentials() just needs one serverURL parameter. It can parse registry and region. 
- Client.GetCredentials() can auto remove the `https://` prefix from serverURL.
- Client.ListCredentials() and ECR.List() can return proxyEndpointUrl which has `https://` prefix.
- Extracted common logics of GetCredentials() and ListCredentials() into a getAuthorizationToken() function.
- Moved some codes from ecr.go to api/client.go.
- Adjusted tests and mocks accordingly. 

@sentientmonkey kindly review. 