### PR TITLE
Add proxy support for retrieve ECR credential

### DIFF
--- a/ecr-login/config/proxy_config.go
+++ b/ecr-login/config/proxy_config.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"os"
+	log "github.com/cihub/seelog"
+	homedir "github.com/mitchellh/go-homedir"
+	"path/filepath"
+	"encoding/json"
+)
+/**
+  Proxy config is used for storing a url to ECR registry mapping.
+  This is useful when setting up a reverse proxy for ECR to cache
+  container data.
+  {"proxies":{"ecrproxy.myasws.com":"12345678910.dkr.ecr.us-east-1.amazonaws.com"}}
+ */
+type ProxyConfig struct {
+	Proxies map[string]string `json:"proxies"`
+}
+
+func GetProxyConfig() (*ProxyConfig, error) {
+	config := ProxyConfig{}
+	dir, _ := homedir.Expand(GetCacheDir())
+
+	//Save it the same as the cache dir now
+	proxyFile := filepath.Join(dir, "ecr_proxy.json")
+	if _, err := os.Stat(proxyFile); err != nil {
+		log.Info("No Proxy config found")
+		return nil, err
+	}
+
+	reader, err := os.Open(proxyFile)
+	if (err != nil) {
+		return nil, err
+	}
+
+	defer reader.Close()
+	if err := json.NewDecoder(reader).Decode(&config); err != nil {
+		log.Errorf("Fail to load config with error %s", err)
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+func GetRegistryURL(serverUrl string) string {
+	proxyConfig, err := GetProxyConfig()
+	if err != nil {
+		return serverUrl
+	}
+	if val, ok := proxyConfig.Proxies[serverUrl]; ok{
+		return val
+	}
+	//Return the input if no mapping found
+	return serverUrl
+}

--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -20,6 +20,7 @@ import (
 	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api"
 	log "github.com/cihub/seelog"
 	"github.com/docker/docker-credential-helpers/credentials"
+	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login/config"
 )
 
 var notImplemented = errors.New("not implemented")
@@ -43,15 +44,16 @@ func (ECRHelper) Delete(serverURL string) error {
 
 func (self ECRHelper) Get(serverURL string) (string, string, error) {
 	defer log.Flush()
-
-	registry, err := api.ExtractRegistry(serverURL)
+	registryURL := config.GetRegistryURL(serverURL)
+	log.Debugf("Get for url: %s", serverURL)
+	registry, err := api.ExtractRegistry(registryURL)
 	if err != nil {
 		log.Errorf("Error parsing the serverURL: %v", err)
 		return "", "", credentials.NewErrCredentialsNotFound()
 	}
 
 	client := self.ClientFactory.NewClientFromRegion(registry.Region)
-	auth, err := client.GetCredentials(serverURL)
+	auth, err := client.GetCredentials(registryURL)
 	if err != nil {
 		log.Errorf("Error retrieving credentials: %v", err)
 		return "", "", credentials.NewErrCredentialsNotFound()


### PR DESCRIPTION
Hi,

In this pull request, I made some changes to support proxy scenario for ecr-credential-helper. Could you help on reviewing and let me know if it can be merged to the master tree? I think  it will be useful for a bunch of scenarios.

- What I did
I add a support to have a reverse proxy before ECR. A reverse proxy is a pull through cache for http requests.  For ex, the reverse proxy can be ecrproxy.myaws.com, the user run docker pull ecrproxy.myaws.com/repo:sha256xx . The reverse proxy will pull from ECR, forward to users and cache the data. This is useful in several scenarios for performance and resiliency.  However, to make this credential helper work, it needs to tell it the ECR url for the credential to retrieve. Right now, it only supports ECR url format

- How I did it
A ecr_proxy.json file that contains a map between proxy url and ecr url like below.

  {"proxies":{"ecrproxy.myasws.com":"12345678910.dkr.ecr.us-east-1.amazonaws.com"}}
Then when processing GET request. Credential helper will check if it can find the key in the map. If so, it uses the REAL url and the workflow goes through

- How to verify it
Tests I have done:
1. Function test: Set up a reverse proxy called ecrproxy.myasws.com (with nginx in this case but it can be any reverse proxy) and forward requests to ecr account. Run docker command lines.

2. Regression tests: Run docker command to directly pull from ECR and everything works.

Docker version: 1.12.5 OS: Ubuntu 14.04

