### PR TITLE
First buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,22 @@
+version: 0.2
+
+phases:
+  install:
+    commands:
+      - ./scripts/hack/symlink-gopath-codebuild.sh
+      - cd /go/src/github.com/awslabs/amazon-ecr-credential-helper
+  pre_build:
+    commands:
+      - echo "Starting tests..."
+      - make test
+  build:
+    commands:
+      - echo "Starting build..."
+      - make all-variants
+  post_build:
+    commands:
+      - echo "Build completed on $(date)"
+artifacts:
+  files:
+      - '**/*'
+  base-directory: 'bin'

--- a/scripts/hack/symlink-gopath-codebuild.sh
+++ b/scripts/hack/symlink-gopath-codebuild.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# This script is meant to make all package available in the 'canonical' location
+# for execution in AWS CodeBuild in the golang container image.
+
+
+if [[ ! -d "/go/src/github.com/awslabs/amazon-ecr-credential-helper" ]]; then
+	mkdir -p "/go/src/github.com/awslabs"
+	ln -s "$(pwd)" "/go/src/github.com/awslabs/amazon-ecr-credential-helper"
+fi


### PR DESCRIPTION
I'd like to rebase this on top of https://github.com/awslabs/amazon-ecr-credential-helper/pull/60 so I can use `make all-variants` instead of `make`, but this works as-is with the `golang:1.9` image as the build environment.

```
$ aws codebuild batch-get-projects --names amazon-ecr-credential-helper
{
    "projectsNotFound": [], 
    "projects": [
        {
            "name": "amazon-ecr-credential-helper", 
            "serviceRole": "--REDACTED--", 
            "tags": [], 
            "artifacts": {
                "namespaceType": "BUILD_ID", 
                "packaging": "NONE", 
                "type": "S3", 
                "location": "--REDACTED--", 
                "name": "amazon-ecr-credential-helper"
            }, 
            "lastModified": 1503641247.019, 
            "timeoutInMinutes": 60, 
            "created": 1503634196.49, 
            "environment": {
                "computeType": "BUILD_GENERAL1_SMALL", 
                "image": "golang:1.9", 
                "type": "LINUX_CONTAINER", 
                "environmentVariables": []
            }, 
            "source": {
                "type": "GITHUB", 
                "location": "https://github.com/samuelkarp/amazon-ecr-credential-helper.git", 
                "auth": {
                    "type": "OAUTH"
                }
            }, 
            "encryptionKey": "--REDACTED--", 
            "arn": "--REDACTED--"
        }
    ]
}
```

@rpnguyen @nmeyerhans