### PR TITLE
Create standalone docker file & allow it to be used for retrieving credentials manually

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,3 +25,4 @@ RUN apk add --no-cache ca-certificates
 COPY --from=builder /go/bin/docker-credential-ecr-login /usr/local/bin/docker-credential-ecr-login
 
 ENTRYPOINT [ "/usr/local/bin/docker-credential-ecr-login" ]
+CMD [ "eval" ]

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#       http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+FROM golang:1.9
+
+WORKDIR /go/src/github.com/awslabs/amazon-ecr-credential-helper
+
+COPY . .
+
+CMD make

--- a/ecr-login/cli/docker-credential-ecr-login/main.go
+++ b/ecr-login/cli/docker-credential-ecr-login/main.go
@@ -41,7 +41,7 @@ func evalCommand(helper credentials.Helper) {
 		var user, token string
 		user, token, err = helper.Get(server)
 		if err == nil {
-			fmt.Printf("docker login -e none -u %s -p %s %s\n", user, token, server)
+			fmt.Printf("docker login -u %s -p %s %s\n", user, token, server)
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
This patch changes the Dockerfile so a proper docker image can be created. The binary within generated docker image is statically linked so it can be used in other Linux based Dockerfiles.

I also added ability to emulate behavior of `aws ecr get-login` so this docker image can be used to pull from ECR when only Docker is available (e.g. CoreOS)