### PR TITLE
change `make docker` to copy from finished container instead of mounting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,18 @@ LINUX_AMD64_BINARY=bin/linux-amd64/$(BINARY_NAME)
 DARWIN_AMD64_BINARY=bin/darwin-amd64/$(BINARY_NAME)
 WINDOWS_AMD64_BINARY=bin/windows-amd64/$(BINARY_NAME).exe
 
+CONTAINER_NAME=build-$(BINARY_NAME)
+
 .PHONY: docker
 docker: Dockerfile
-	docker run --rm \
-	-e TARGET_GOOS=$(TARGET_GOOS) \
-	-e TARGET_GOARCH=$(TARGET_GOARCH) \
-	-v $(shell pwd)/bin:/go/src/github.com/awslabs/amazon-ecr-credential-helper/bin \
-	$(shell docker build -q .)
+	docker run \
+		--name $(CONTAINER_NAME) \
+		-e TARGET_GOOS=$(TARGET_GOOS) \
+		-e TARGET_GOARCH=$(TARGET_GOARCH) \
+		$(shell docker build -q .)
+	mkdir -p bin/local
+	docker cp $(CONTAINER_NAME):/go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/local/$(BINARY_NAME) $(LOCAL_BINARY)
+	docker rm $(CONTAINER_NAME)
 
 .PHONY: build
 build: $(LOCAL_BINARY)


### PR DESCRIPTION
Currently `make docker` works by mounting the output dir on the host into the build container.
This means it can't be used when the build environment is itself a docker container.

This PR changes the docker build behaviour to instead run the build container without mounting, and then copying the binary out of the finished container before removing it.

Benefits:
 - works when building inside container environments

Drawbacks:
 - slightly more complicated
 - because the build container is removed each time, `make docker` builds from scratch every time (if this is an issue it could be worked around with the drawback of more complexity in the Makefile)
 - requires Docker 1.8

