### PR TITLE
Support "docker build"

### DIFF
--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -16,6 +16,7 @@ package ecr
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api"
 	log "github.com/cihub/seelog"
@@ -74,6 +75,9 @@ func (self ECRHelper) List() (map[string]string, error) {
 	for _, auth := range auths {
 		serverURL := auth.ProxyEndpoint
 		result[serverURL] = auth.Username
+		// Add an element without scheme
+		// because "docker build" fails if the base image is an image in ECR
+		result[strings.TrimPrefix(serverURL, "https://")] = auth.Username
 	}
 	return result, nil
 }

--- a/ecr-login/ecr_test.go
+++ b/ecr-login/ecr_test.go
@@ -105,8 +105,9 @@ func TestListSuccess(t *testing.T) {
 
 	serverList, err := helper.List()
 	assert.NoError(t, err)
-	assert.Len(t, serverList, 1)
+	assert.Len(t, serverList, 2)
 	assert.Equal(t, expectedUsername, serverList[proxyEndpointUrl])
+	assert.Equal(t, expectedUsername, serverList[proxyEndpoint])
 }
 
 func TestListFailure(t *testing.T) {


### PR DESCRIPTION
"docker build" fails if the base image is an image in ECR.
For example, if we try to build an image using Dockerfile
with a content like below:

```
From XXXXXXXXXX.dkr.ecr.ap-northeast-1.amazonaws.com/test
```

we will receive an error message like "repository
XXXXXXXXXX.dkr.ecr.ap-northeast-1.amazonaws.com/test
not found: does not exist or no pull access".

I think this change will resolve https://github.com/awslabs/amazon-ecr-credential-helper/issues/76.