### PR TITLE
Test Go 1.10, cross-compilation targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ os:
     - linux
     - osx
 go:
-    - 1.7.x
-    - 1.8.x
-    - 1.9
+    - "1.7.x"
+    - "1.8.x"
+    - "1.9"
+    - "1.10"
 go_import_path: github.com/awslabs/amazon-ecr-credential-helper
 install: make get-deps
 script:
+    - make all-variants
     - make test

--- a/ecr-login/api/client.go
+++ b/ecr-login/api/client.go
@@ -33,12 +33,12 @@ const programName = "docker-credential-ecr-login"
 var ecrPattern = regexp.MustCompile(`(^[a-zA-Z0-9][a-zA-Z0-9-_]*)\.dkr\.ecr\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.amazonaws\.com(\.cn)?`)
 
 type Registry struct {
-	ID	string
-	Region	string
+	ID     string
+	Region string
 }
 
 func ExtractRegistry(serverURL string) (*Registry, error) {
-	if (strings.HasPrefix(serverURL, proxyEndpointScheme)) {
+	if strings.HasPrefix(serverURL, proxyEndpointScheme) {
 		serverURL = strings.TrimPrefix(serverURL, proxyEndpointScheme)
 	}
 	matches := ecrPattern.FindStringSubmatch(serverURL)
@@ -48,8 +48,8 @@ func ExtractRegistry(serverURL string) (*Registry, error) {
 		return nil, fmt.Errorf(serverURL + "is not a valid repository URI for Amazon Elastic Container Registry.")
 	}
 	registry := &Registry{
-		ID:	matches[1],
-	        Region:	matches[2],
+		ID:     matches[1],
+		Region: matches[2],
 	}
 	return registry, nil
 }
@@ -126,12 +126,12 @@ func (self *defaultClient) ListCredentials() ([]*Auth, error) {
 		return auths, err
 	}
 
-	return auths, nil 
+	return auths, nil
 }
 
 func (self *defaultClient) getAuthorizationToken(registryID string) (*Auth, error) {
 	var input *ecr.GetAuthorizationTokenInput
-        if registryID == "" {
+	if registryID == "" {
 		log.Debugf("Calling ECR.GetAuthorizationToken for default registry")
 		input = &ecr.GetAuthorizationTokenInput{}
 	} else {
@@ -188,7 +188,7 @@ func extractToken(token string, proxyEndpoint string) (*Auth, error) {
 
 	parts := strings.SplitN(string(decodedToken), ":", 2)
 	if len(parts) < 2 {
-		return nil, fmt.Errorf("Invalid token: expected two parts, got %n", len(parts))
+		return nil, fmt.Errorf("Invalid token: expected two parts, got %d", len(parts))
 	}
 
 	return &Auth{


### PR DESCRIPTION
*Description of changes:*
* Added 1.10 to the list of Go versions that are tested
* Ensured that the cross-compilation targets defined in the Makefile are tested
* Ran `gofmt -s` on `api/client.go`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
