### PR TITLE
Create bin directory for docker output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ WINDOWS_AMD64_BINARY=bin/windows-amd64/$(BINARY_NAME).exe
 
 .PHONY: docker
 docker: Dockerfile
+	mkdir -p bin
 	docker run --rm \
 	-e TARGET_GOOS=$(TARGET_GOOS) \
 	-e TARGET_GOARCH=$(TARGET_GOARCH) \


### PR DESCRIPTION
If we just clone this repository and do `make docker` the command won't work.
We must ensure bin directory exists before mounting docker volume for build.

*Issue #* #62 

*Description of changes:*
create bin directory before running docker that mounts it as a volume.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
