### PR TITLE
Initial Amazon Linux packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,16 @@
 GITCOMMIT_SHA
 *.tar.gz
 *.tar
+
+
+# Amazon Linux RPM
+*.swp
+/BUILDROOT/
+/BUILD/
+/RPMS/
+/SRPMS/
+/SOURCES
+/SPECS/
+/.rpm-done
+/sources.tgz
+/*.rpm

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ LINUX_AMD64_BINARY=bin/linux-amd64/$(BINARY_NAME)
 DARWIN_AMD64_BINARY=bin/darwin-amd64/$(BINARY_NAME)
 WINDOWS_AMD64_BINARY=bin/windows-amd64/$(BINARY_NAME).exe
 
+include Makefile.amazonlinux
+
 .PHONY: docker
 docker: Dockerfile
 	mkdir -p bin
@@ -96,7 +98,7 @@ get-deps:
 	go get golang.org/x/tools/cmd/goimports
 
 .PHONY: clean
-clean:
+clean: .clean-amazonlinux
 	- rm -rf ./bin
 	- rm -f GITCOMMIT_SHA
 	- rm -f release.tar.gz

--- a/Makefile.amazonlinux
+++ b/Makefile.amazonlinux
@@ -1,0 +1,48 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# 	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+# Hook to perform preparation steps prior to the sources target.
+prepare-sources::
+
+sources: prepare-sources release.tar.gz
+
+.srpm-done: release.tar.gz
+	test -e SOURCES || ln -s . SOURCES
+	rpmbuild --define "%_topdir $(PWD)" -bs amazon-ecr-credential-helper.spec
+	find SRPMS/ -type f -exec cp {} . \;
+	touch .srpm-done
+
+srpm: .srpm-done
+
+.rpm-done: release.tar.gz
+	test -e SOURCES || ln -s . SOURCES
+	chown ${UID}.${UID} SOURCES/release.tar.gz
+	rpmbuild --define "%_topdir $(PWD)" -bb amazon-ecr-credential-helper.spec
+	find RPMS/ -type f -exec cp {} . \;
+	touch .rpm-done
+
+rpm: .rpm-done
+
+.PHONY: docker-rpm
+docker-rpm:
+	docker run --rm \
+	-v '$(shell pwd)':/sources \
+	$(shell docker build --network=host -f packaging/amazon-linux/Dockerfile.rpm -q .)
+
+.PHONY: .clean-amazonlinux
+.clean-amazonlinux:
+	-rm -f ./sources.tgz
+	-rm -rf ./BUILDROOT BUILD RPMS SRPMS SOURCES SPECS
+	-rm -rf ./x86_64
+	-rm -f amazon-ecr-credential-helper-*.rpm
+	-rm -f .srpm-done .rpm-done

--- a/amazon-ecr-credential-helper.spec
+++ b/amazon-ecr-credential-helper.spec
@@ -1,0 +1,118 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the
+# "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and
+# limitations under the License.
+Name:           amazon-ecr-credential-helper
+Version:        0.1.0
+Release:        0%{?dist}
+Group:          Development/Tools
+Vendor:         Amazon.com
+License:        Apache 2.0
+Summary:        Amazon ECR Docker Credential Helper
+BuildArch:      x86_64
+BuildRoot:      ${_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+Source0: release.tar.gz
+
+BuildRequires: golang >= 1.7
+
+# The following 'Provides' lists the vendored dependencies bundled in
+# and used to produce the amazon-ecr-credential-helper package. As dependencies
+# are added or removed, this list should also be updated accordingly.
+#
+# You can use this to generate a list of the appropriate Provides
+# statements by reading out the vendor directory:
+#
+# find ../../ecr-login/vendor -name \*.go -exec dirname {} \; | sort | uniq | sed 's,^.*ecr-login/vendor/,,; s/^/bundled(golang(/; s/$/))/;' | sed 's/^/Provides:\t/' | expand -
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/awserr))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/awsutil))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/client))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/client/metadata))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/corehandlers))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/credentials))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/credentials/endpointcreds))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/credentials/stscreds))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/csm))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/defaults))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/ec2metadata))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/endpoints))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/request))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/session))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/aws/signer/v4))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/internal/ini))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/internal/sdkio))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/internal/sdkrand))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/internal/sdkuri))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/internal/shareddefaults))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/private/protocol))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/private/protocol/json/jsonutil))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/private/protocol/jsonrpc))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/private/protocol/query))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/private/protocol/query/queryutil))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/private/protocol/rest))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/service/ecr))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/service/ecr/ecriface))
+Provides:       bundled(golang(github.com/aws/aws-sdk-go/service/sts))
+Provides:       bundled(golang(github.com/davecgh/go-spew/spew))
+Provides:       bundled(golang(github.com/docker/docker-credential-helpers/credentials))
+Provides:       bundled(golang(github.com/golang/mock/gomock))
+Provides:       bundled(golang(github.com/jmespath/go-jmespath))
+Provides:       bundled(golang(github.com/konsorten/go-windows-terminal-sequences))
+Provides:       bundled(golang(github.com/mitchellh/go-homedir))
+Provides:       bundled(golang(github.com/pkg/errors))
+Provides:       bundled(golang(github.com/pmezard/go-difflib/difflib))
+Provides:       bundled(golang(github.com/sirupsen/logrus))
+Provides:       bundled(golang(github.com/stretchr/testify/assert))
+Provides:       bundled(golang(golang.org/x/crypto/ssh/terminal))
+Provides:       bundled(golang(golang.org/x/net/context))
+Provides:       bundled(golang(golang.org/x/sys/unix))
+Provides:       bundled(golang(golang.org/x/sys/windows))
+
+%description
+The Amazon ECR Docker Credential Helper is a credential helper for the Docker
+daemon that makes it easier to use Amazon Elastic Container Registry.
+
+%prep
+%setup -c
+
+%build
+export GOPATH="$(pwd)/_gopath"
+mkdir -p "_gopath/src/github.com/awslabs"
+ln -sv "$(pwd)" "_gopath/src/github.com/awslabs/amazon-ecr-credential-helper"
+cd "_gopath/src/github.com/awslabs/amazon-ecr-credential-helper"
+make
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/%{_bindir}
+install -p -m 0755 \
+  bin/local/docker-credential-ecr-login \
+  %{buildroot}%{_bindir}/docker-credential-ecr-login
+install -D -m 0644 \
+  docs/docker-credential-ecr-login.1 \
+  %{buildroot}%{_mandir}/man1/docker-credential-ecr-login.1
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/docker-credential-ecr-login
+%{_mandir}/man1/docker-credential-ecr-login.1*
+
+%clean
+rm -rf %{buildroot}
+
+%changelog
+* Fri Nov 2 2018 Samuel Karp <skarp@amazon.com> - 0.1.0-0
+- Initial packaging
+- Contains changes unreleased in 0.1.0, should not be published as-is

--- a/docs/packaging-amazon-linux.md
+++ b/docs/packaging-amazon-linux.md
@@ -1,0 +1,16 @@
+# Packaging for Amazon Linux
+
+Packaging sources for Amazon Linux are contained in the
+(`amazonlinux` branch)[https://github.com/awslabs/amazon-ecr-credential-helper/tree/amazonlinux].
+
+This branch is updated every time a release is prepared for Amazon Linux.
+
+To prepare a release, update the `amazon-ecr-credential-helper.spec` file in
+the root of this repository with the new version number (or release number)
+and with appropriate changes in the `changelog` section.
+
+To build an RPM locally for testing, you can use the `rpm` target in the
+Makefile (`make rpm`) or use the `docker-rpm` target, which will use an
+`amazonlinux:2` Docker container as a build environment.  Both targets will
+generate artifacts in this repository which can be cleaned by running
+`make clean`.

--- a/packaging/amazon-linux/Dockerfile.rpm
+++ b/packaging/amazon-linux/Dockerfile.rpm
@@ -1,0 +1,22 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#       http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+FROM amazonlinux:2
+
+WORKDIR /sources
+
+RUN yum install -y rpm-build make golang git
+
+COPY . .
+
+CMD make rpm


### PR DESCRIPTION
*Description of changes:*
Initial packaging of an RPM for Amazon Linux 2.

Tested with `make docker-rpm`, which produced `amazon-ecr-credential-helper-0.1.0-1.amzn2.x86_64.rpm` and was install-able into an `amazonlinux:2` container.

Still TODO:
- [x] Fix git SHA embedding with `make docker-rpm` (depends on https://github.com/awslabs/amazon-ecr-credential-helper/pull/126)
- [x] Add changelog
- [x] Declare bundled dependencies
- [x] Test with actual Amazon Linux build system

/cc @jahkeup 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
