### PR TITLE
snap: initial packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@
 GITCOMMIT_SHA
 *.tar.gz
 *.tar
+
+# Snaps
+*.snap
+parts/
+prime/
+stage/
+snap/.snapcraft

--- a/scripts/snap-in-docker.sh
+++ b/scripts/snap-in-docker.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Normalize to working directory being build root (up one level from ./snap)
+SOURCES=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
+
+# docker build needs context, but we don't really want to provide any
+TMPCONTEXT=$(mktemp -d)
+docker build \
+       --network=host \
+       -t amazon/amazon-ecr-credential-helper:snapcraft \
+       -f scripts/snapcraft.dockerfile \
+       "${TMPCONTEXT}"
+
+rmdir "${TMPCONTEXT}"
+
+docker run \
+       --rm -it\
+       --net=host \
+       -v ${SOURCES}:/build \
+       amazon/amazon-ecr-credential-helper:snapcraft \
+       snapcraft \
+       $@

--- a/scripts/snapcraft.dockerfile
+++ b/scripts/snapcraft.dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:18.04
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    golang-go \
+    make \
+    git \
+    snapcraft
+
+WORKDIR /build
+CMD ["snapcraft"]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,34 @@
+name: docker-credential-ecr-login
+version: '0.2.0-dev'
+summary: Amazon ECR Credential Helper for Docker
+description: |
+  A Docker helper to automatically manage credentials for Amazon ECR.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+#confinement: devmode # use 'strict' once you have the right plugs and slots
+confinement: classic
+
+apps:
+  docker-credential-ecr-login:
+    command: docker-credential-ecr-login
+#    plugs:
+#      - home
+#      - network
+
+parts:
+  docker-credential-ecr-login:
+    source: .
+    plugin: go
+    go-importpath: github.com/awslabs/amazon-ecr-credential-helper
+    override-build: |
+      BUILDDIR=$(pwd)
+      INSTALLDIR=${BUILDDIR}/../install
+      export GOPATH=$(pwd)/../go
+      cd ../go/src/github.com/awslabs/amazon-ecr-credential-helper
+      make
+      cp bin/local/docker-credential-ecr-login $INSTALLDIR
+      mkdir -p $INSTALLDIR/usr/share/doc/docker-credential-ecr-login
+      cp LICENSE NOTICE THIRD-PARTY-LICENSES $INSTALLDIR/usr/share/doc/docker-credential-ecr-login
+      gzip --keep --force docs/docker-credential-ecr-login.1
+      mkdir -p $INSTALLDIR/usr/share/man/man1
+      cp docs/docker-credential-ecr-login.1.gz $INSTALLDIR/usr/share/man/man1


### PR DESCRIPTION
*Description of changes:*
Initial packaging as a [snap](https://snapcraft.io/) package.

This needs review in the following areas:

* Is it possible for us to get away from needing `classic` confinement?  The `home` plug does not allow reading hidden directories, and we need to read `~/.aws` (and write to `~/.ecr`, but that could really be confined inside the snap's `$HOME` instead of the user's).
* The `snapcore/snapcraft` Docker image is based on Ubuntu 16.04, which does not have a new enough `golang-go` package for this project to build.  Consequently, I wrote a Dockerfile to build from Ubuntu 18.04 which has Go 1.10 available.
* The snap name is `docker-credential-ecr-login` as that seems to be the only way for a binary named `docker-credential-ecr-login` to be added to the user's `$PATH`, and Docker requires that naming scheme.  Is it possible to name the snap something more meaningful (like `amazon-ecr-credential-helper` while still exposing a binary that appears as `docker-credential-ecr-login` in `$PATH`?
* I used `override-build` to control the build process and actually use our `Makefile`, but it does then mean manually handling copying files to the appropriate location.  Is there a way to either still use our `Makefile` or to inject the appropriate Go options (including injecting the project version and commit into the binary)?

/cc @davdunc

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
