### PR TITLE
Correctly handle UnknownServiceError

### DIFF
--- a/ecr-login/api/factory.go
+++ b/ecr-login/api/factory.go
@@ -63,7 +63,6 @@ func (defaultClientFactory DefaultClientFactory) NewClientWithFipsEndpoint(regio
 	awsSession := session.New()
 	awsSession.Handlers.Build.PushBackNamed(userAgentHandler)
 
-	// UnknownServiceError is expected for "ecr-fips", but resolver should still generate correct FIPs endpoint
 	endpoint, _ := getServiceEndpoint("ecr-fips", region)
 
 	awsConfig := awsSession.Config.WithEndpoint(endpoint).WithRegion(region)
@@ -102,6 +101,8 @@ func (defaultClientFactory DefaultClientFactory) NewClientWithOptions(opts Optio
 
 func getServiceEndpoint(service, region string) (string, error) {
 	resolver := endpoints.DefaultResolver()
-	endpoint, err := resolver.EndpointFor(service, region)
+	endpoint, err := resolver.EndpointFor(service, region, func(opts *endpoints.Options) {
+		opts.ResolveUnknownService = true
+	})
 	return endpoint.URL, err
 }

--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -54,7 +54,11 @@ func (self ECRHelper) Get(serverURL string) (string, string, error) {
 
 	var client api.Client
 	if registry.FIPS {
-		client = self.ClientFactory.NewClientWithFipsEndpoint(registry.Region)
+		client, err = self.ClientFactory.NewClientWithFipsEndpoint(registry.Region)
+		if err != nil {
+			logrus.WithError(err).Error("Error resolving FIPS endpoint")
+			return "", "", credentials.NewErrCredentialsNotFound()
+		}
 	} else {
 		client = self.ClientFactory.NewClientFromRegion(registry.Region)
 	}

--- a/ecr-login/mocks/ecr_mocks.go
+++ b/ecr-login/mocks/ecr_mocks.go
@@ -86,10 +86,11 @@ func (mr *MockClientFactoryMockRecorder) NewClientWithDefaults() *gomock.Call {
 }
 
 // NewClientWithFipsEndpoint mocks base method
-func (m *MockClientFactory) NewClientWithFipsEndpoint(arg0 string) api.Client {
+func (m *MockClientFactory) NewClientWithFipsEndpoint(arg0 string) (api.Client, error) {
 	ret := m.ctrl.Call(m, "NewClientWithFipsEndpoint", arg0)
 	ret0, _ := ret[0].(api.Client)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // NewClientWithFipsEndpoint indicates an expected call of NewClientWithFipsEndpoint


### PR DESCRIPTION
Setting ResolveUnknownService flag to be true on the Endpoint Resolver
allows the resolver to fall back to its default endpoint construction
pattern if it cannot find an explicit reference to a service endpoint.
This allows proper handling of cases where services may not
have released an updated endpoints definition.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
