### PR TITLE
docs: add community-maintained packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Docker to work with the helper.
 ### Mac OS
 A community-maintained Homebrew formula is available in the core tap.
 
+[![Homebrew package](https://repology.org/badge/version-for-repo/homebrew/docker-credential-helper-ecr.svg)](https://repology.org/metapackage/docker-credential-helper-ecr/versions)
+
 ```bash
 $ brew install docker-credential-helper-ecr
 ```
@@ -57,6 +59,8 @@ Docker to work with the helper.
 
 ### Arch Linux
 A community-maintained package is available in the Arch User Repository.
+
+[![AUR package](https://repology.org/badge/version-for-repo/aur/amazon-ecr-credential-helper.svg)](https://repology.org/metapackage/amazon-ecr-credential-helper/versions)
 
 ```bash
 $ git clone https://aur.archlinux.org/amazon-ecr-credential-helper.git

--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ Once you have installed the credential helper, see the
 [Configuration section](#Configuration) for instructions on how to configure
 Docker to work with the helper.
 
+### Arch Linux
+A community-maintained package is available in the Arch User Repository.
+
+```bash
+$ git clone https://aur.archlinux.org/amazon-ecr-credential-helper.git
+$ cd amazon-ecr-credential-helper
+$ makepkg -si
+```
+
+Once you have installed the credential helper, see the
+[Configuration section](#Configuration) for instructions on how to configure
+Docker to work with the helper.
+
 ### From Source
 To build and install the Amazon ECR Docker Credential Helper, we suggest Go
 1.9+, `git` and `make` installed on your system.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -7,10 +7,15 @@ operating systems:
   ([source](https://github.com/awslabs/amazon-ecr-credential-helper/tree/amazonlinux),
   [packaging documentation](https://github.com/awslabs/amazon-ecr-credential-helper/blob/amazonlinux/docs/packaging-amazon-linux.md))
   
-There is community-maintained packaging for the Amazon ECR Credential Helper on
+There are community-maintained packages for the Amazon ECR Credential Helper on
 the following operating systems:
 
-* Mac OS X ([source](https://github.com/Homebrew/homebrew-core/blob/master/Formula/docker-credential-helper-ecr.rb))
+* Mac OS X (with the Homebrew package manager)
+  ([source](https://github.com/Homebrew/homebrew-core/blob/master/Formula/docker-credential-helper-ecr.rb))
+* NixOS (and the Nix package manager)
+  ([source](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/admin/amazon-ecr-credential-helper/default.nix))
+* Arch Linux (in the Arch User Repository)
+  ([source](https://aur.archlinux.org/packages/amazon-ecr-credential-helper))
 
 If you are interested in packaging the Amazon ECR Credential Helper, please get
 in touch!  We can list your community-maintained packaging here and include


### PR DESCRIPTION
*Description of changes:*
Additional community-maintained packages are listed at https://repology.org/metapackage/amazon-ecr-credential-helper/versions; adding them here.

I don't have installation instructions in the README for Nix/NixOS yet; I'd welcome suggestions for that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
