### PR TITLE
docs: Fix markdown link syntax

### DIFF
--- a/docs/packaging-amazon-linux.md
+++ b/docs/packaging-amazon-linux.md
@@ -1,7 +1,7 @@
 # Packaging for Amazon Linux
 
 Packaging sources for Amazon Linux are contained in the
-(`amazonlinux` branch)[https://github.com/awslabs/amazon-ecr-credential-helper/tree/amazonlinux].
+[`amazonlinux` branch](https://github.com/awslabs/amazon-ecr-credential-helper/tree/amazonlinux).
 
 This branch is updated every time a release is prepared for Amazon Linux.
 


### PR DESCRIPTION

*Description of changes:*

Fix markdown link in the packaging docs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
