### PR TITLE
Extra notes for installing from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ Docker to work with the helper.
 To build and install the Amazon ECR Docker Credential Helper, we suggest Go
 1.9+, `git` and `make` installed on your system.
 
+If you just installed Go, make sure you also have added it to your PATH or 
+Environment Vars (Windows). For example:
+
+```
+$ export GOPATH=$HOME/gocode
+$ export PATH=$PATH:$GOPATH/bin
+```
+
+Or in Windows:
+
+```
+<your existing PATH definitions>;C:\Users\<username>\gocode\bin\
+```
+
+If you haven't defined the PATH, the command below will fail silently, and
+running `docker-credential-ecr-login` will output: `command not found`
+
 You can install this via `go get` with:
 
 ```

--- a/README.md
+++ b/README.md
@@ -111,14 +111,15 @@ If you just installed Go, make sure you also have added it to your PATH or
 Environment Vars (Windows). For example:
 
 ```
-$ export GOPATH=$HOME/gocode
+$ export GOPATH=$HOME/go
 $ export PATH=$PATH:$GOPATH/bin
 ```
 
 Or in Windows:
 
 ```
-<your existing PATH definitions>;C:\Users\<username>\gocode\bin\
+setx GOPATH %USERPROFILE%\go
+<your existing PATH definitions>;%USERPROFILE%\go\bin
 ```
 
 If you haven't defined the PATH, the command below will fail silently, and


### PR DESCRIPTION
*Issue #, if available:* 101

Added note about golang PATH definitions being required prior to installing from source. Otherwise the install will fail silently.