### PR TITLE
.codebuild: scripts for release pipeline

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -3,6 +3,8 @@ version: 0.2
 phases:
   install:
     commands:
+      - chmod +x -R scripts
+      - ./scripts/hack/codepipeline-git-commit.sh
       - ./scripts/hack/symlink-gopath-codebuild.sh
       - cd /go/src/github.com/awslabs/amazon-ecr-credential-helper
   pre_build:

--- a/.codebuild/source-archive.yml
+++ b/.codebuild/source-archive.yml
@@ -1,0 +1,18 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - ./scripts/hack/codepipeline-source-archive.sh
+      - ./scripts/hack/version-changelog.sh | tee archive/VERSION_CHANGELOG.md
+  post_build:
+    commands:
+      - echo "Archive completed on $(date)"
+artifacts:
+  files:
+    - 'release.tar.gz'
+    - 'release-novendor.tar.gz'
+    - 'VERSION'
+    - 'GITCOMMIT_SHA'
+    - 'VERSION_CHANGELOG.md'
+  base-directory: 'archive'

--- a/scripts/hack/codepipeline-git-commit.sh
+++ b/scripts/hack/codepipeline-git-commit.sh
@@ -12,11 +12,11 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# This script is meant to make the package available in the 'canonical' location
-# for execution in AWS CodeBuild in the golang container image.
+# This script populates the GITCOMMIT_SHA file when built inside AWS CodeBuild
+# and invoked from AWS CodePipeline.
 
+set -ex
 
-if [[ ! -d "/go/src/github.com/awslabs/amazon-ecr-credential-helper" ]]; then
-	mkdir -p "/go/src/github.com/awslabs"
-	ln -s "$(pwd)" "/go/src/github.com/awslabs/amazon-ecr-credential-helper"
-fi
+[[ -z "${CODEBUILD_RESOLVED_SOURCE_VERSION}" ]] && exit 1
+echo "${CODEBUILD_RESOLVED_SOURCE_VERSION}" > GITCOMMIT_SHA
+cat GITCOMMIT_SHA

--- a/scripts/hack/codepipeline-source-archive.sh
+++ b/scripts/hack/codepipeline-source-archive.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# This script checks out a git repository with the correct revision for
+# execution in AWS CodeBuild when triggered by AWS CodePipeline and produces a
+# source archive.
+# The script assumes that you have the following environment variables set:
+# * CODEBUILD_RESOLVED_SOURCE_VERSION - Set automatically when AWS CodePipeline
+#   invokes AWS CodeBuild
+# * GIT_REMOTE - A valid git remote that will be cloned
+# This script is meant to be triggered only from branch-based executions of the
+# pipeline.  It does not handle pull requests.
+
+set -ex
+
+[[ -d .git ]] && exit 1
+[[ -z "${CODEBUILD_RESOLVED_SOURCE_VERSION}" ]] && exit 1
+[[ -z "${GIT_REMOTE}" ]] && exit 1
+
+
+mkdir archive
+git clone "${GIT_REMOTE}" archive
+cd archive
+git checkout "${CODEBUILD_RESOLVED_SOURCE_VERSION}"
+make release-tarball
+make release-tarball-no-vendor

--- a/scripts/hack/version-changelog.sh
+++ b/scripts/hack/version-changelog.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# This script is an incredibly simple parser for the CHANGELOG.md in this
+# repository.  It expects the changelog to have the following format:
+#
+# * Sections delimited by "#"
+# * Section titles matching the VERSION file
+#
+# For example, consider the following sample changelog:
+#
+# # 1.2.3
+# * Foo
+# # 0.1.2-alpha
+# * Bar
+#
+# If the VERSION file is set to "0.1.2-alpha", the output of this script is:
+#
+# # 0.1.2-alpha
+# * Bar
+set -e
+
+# Normalize to working directory being source root (up two levels)
+ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )
+cd "${ROOT}"
+
+VERSION="$(cat VERSION)"
+
+
+match=""
+while IFS= read -r line; do
+    if [[ "${line:0:1}" == "#" ]]; then
+        if [[ "${line}" == "# ${VERSION}" ]]; then
+            match="y"
+            continue
+        else
+            match=""
+        fi
+    fi
+    if [[ -n "${match}" ]]; then
+        echo "$line"
+    fi
+done < "CHANGELOG.md"


### PR DESCRIPTION
This commit sets up buildspecs for two different AWS CodeBuild builds,
intended to be run from AWS CodePipeline.  The main buildspec builds all
variants of the binary, and can also be run directly in AWS CodeBuild
with no changes.  The second buildspec produces correct source archives
that include commit information but not a complete git repository, as
well as metadata files like a version-specific section of the
CHANGELOG.md.

cc @sipsma

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
