### PR TITLE
Fix `make docker` when repo is a submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ DARWIN_AMD64_BINARY=bin/darwin-amd64/$(BINARY_NAME)
 WINDOWS_AMD64_BINARY=bin/windows-amd64/$(BINARY_NAME).exe
 
 .PHONY: docker
-docker: Dockerfile
+docker: Dockerfile GITCOMMIT_SHA
 	mkdir -p bin
 	docker run --rm \
 	-e TARGET_GOOS=$(TARGET_GOOS) \


### PR DESCRIPTION
*Issue #, if available:* #184 

*Description of changes:*

* Made `GITCOMMIT_SHA` a dependency of the `docker` Make target.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
