### PR TITLE
debian: remove Files-Excluded from d/copyright

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -2,8 +2,6 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: amazon-ecr-credential-helper
 Upstream-Contact: Samuel Karp <skarp@amazon.com>
 Source: https://github.com/awslabs/amazon-ecr-credential-helper
-Files-Excluded:
-  vendor
 
 Files: *
 Copyright: 2016-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.


### PR DESCRIPTION
This package is now built using an upstream tarball that does not
contain the excluded files.  Removing the Files-Excluded marker as they
are not included in that tarball.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
