### PR TITLE
api: enable shared config by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ include:
 To use credentials associated with a different named profile in the shared credentials file (`~/.aws/credentials`), you
 may set the `AWS_PROFILE` environment variable. 
 
-The Amazon ECR Docker Credential Helper can optionally read and support some configuration options specified in the AWS
-shared configuration file (`~/.aws/config`).  To use these options, you must set the `AWS_SDK_LOAD_CONFIG` environment
-variable to `true`.  The supported options include:
+The Amazon ECR Docker Credential Helper reads and supports some configuration options specified in the AWS
+shared configuration file (`~/.aws/config`).  To disable these options, you must set the `AWS_SDK_LOAD_CONFIG` environment
+variable to `false`.  The supported options include:
 
 * Assumed roles specified with `role_arn` and `source_profile`
 * External credential processes specified with `credential_process`
@@ -202,12 +202,10 @@ The credentials must have a policy applied that
 `docker push 123456789012.dkr.ecr.us-west-2.amazonaws.com/my-repository:my-tag`
 
 If you have configured additional profiles for use with the AWS CLI, you can use
-those profiles by specifying the `AWS_PROFILE` environment variable when
-invoking `docker`.  If your profiles use assumed roles or additional credential
-providing processes, you will also need to specify `AWS_SDK_LOAD_CONFIG=true`.
+those profiles by specifying the `AWS_PROFILE` environment variable when invoking `docker`.
 For example:
 
-`AWS_SDK_LOAD_CONFIG=true AWS_PROFILE=myprofile docker pull 123456789012.dkr.ecr.us-west-2.amazonaws.com/my-repository:my-tag`
+`AWS_PROFILE=myprofile docker pull 123456789012.dkr.ecr.us-west-2.amazonaws.com/my-repository:my-tag`
 
 There is no need to use `docker login` or `docker logout`.
 

--- a/docs/docker-credential-ecr-login.1
+++ b/docs/docker-credential-ecr-login.1
@@ -64,10 +64,10 @@ EC2 instance profiles, and ECS task roles.
 To use credentials associated with a different named profile in the shared
 credentials file, you may set the \fIAWS_PROFILE\fP environment variable.
 
-The credential helper can optionally read and support some configuration
+The credential helper reads and supports some configuration
 options specified in the shared configuration file (\fI~/.aws/config\fP).  To
-use these options, you must set the \fIAWS_SDK_LOAD_CONFIG\fP environment
-variable to \fItrue\fP.  The supported options include:
+disable these options, you must set the \fIAWS_SDK_LOAD_CONFIG\fP environment
+variable to \fIfalse\fP.  The supported options include:
 .IP \[bu] 2
 Assumed roles specified with \fIrole_arn\fP and \fIsource_profile\fP
 .IP \[bu]

--- a/ecr-login/api/factory_test.go
+++ b/ecr-login/api/factory_test.go
@@ -1,0 +1,48 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package api
+
+import (
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/stretchr/testify/assert"
+)
+
+const loadConfigEnvVar = "AWS_SDK_LOAD_CONFIG"
+
+func TestSharedConfigState(t *testing.T) {
+	defer func(value string) {
+		os.Setenv(loadConfigEnvVar, value)
+	}(os.Getenv(loadConfigEnvVar))
+
+	cases := []struct {
+		envValue string
+		expected session.SharedConfigState
+	}{
+		{"", session.SharedConfigEnable},
+		{"true", session.SharedConfigEnable},
+		{"false", session.SharedConfigDisable},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.envValue, func(t *testing.T) {
+			os.Setenv(loadConfigEnvVar, testCase.envValue)
+			state := loadSharedConfigState()
+			assert.NotNil(t, state)
+			assert.Equal(t, testCase.expected, state)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #198 

*Description of changes:*
The AWS SDK for Go ignores the shared config file `~/.aws/config` by
default, which is the inherited behavior of
amazon-ecr-credential-helper. This commit changes the default behavior
to have `~/.aws/config` enabled.

The shared config file usage can be controlled through the environment
variable `AWS_SDK_LOAD_CONFIG`. To disable this behavior, set
`AWS_SDK_LOAD_CONFIG=false`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
