### PR TITLE
Use the XDG Basedir Spec for the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ There is no need to use `docker login` or `docker logout`.
 
 ## Troubleshooting
 
-Logs from the Amazon ECR Docker Credential Helper are stored in `~/.ecr/log`.
+Logs from the Amazon ECR Docker Credential Helper are stored inside you cache
+files directory (e.g.: `~/.cache/ecr/log` on *nix).
 
 For more information about Amazon ECR, see the the
 [Amazon Elastic Container Registry User Guide](http://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html).

--- a/ecr-login/config/cache_dir.go
+++ b/ecr-login/config/cache_dir.go
@@ -19,9 +19,7 @@ func GetCacheDir() string {
 	if cacheDir := os.Getenv("AWS_ECR_CACHE_DIR"); cacheDir != "" {
 		return cacheDir
 	}
-	xdgDir := os.Getenv("XDG_CACHE_HOME");
-	if xdgDir == "" {
-		xdgDir = "~/.cache"
-	}
-	return xdgDir + "/ecr"
+	dir, _ := os.UserCacheDir()
+
+	return dir + "/ecr"
 }

--- a/ecr-login/config/cache_dir.go
+++ b/ecr-login/config/cache_dir.go
@@ -19,5 +19,9 @@ func GetCacheDir() string {
 	if cacheDir := os.Getenv("AWS_ECR_CACHE_DIR"); cacheDir != "" {
 		return cacheDir
 	}
-	return "~/.ecr"
+	xdgDir := os.Getenv("XDG_CACHE_HOME");
+	if xdgDir == "" {
+		xdgDir = "~/.cache"
+	}
+	return xdgDir + "/ecr"
 }


### PR DESCRIPTION
Currently, for caching data, a new directory is created in the current user's home directory. This is bad practice (if all apps just dump files into the user's home, it becomes somewhat unmaintainable).

The XDG Basedir Specification covers this pretty neatly; the cache directory for all applications is configurable via the `XDG_CACHE_HOME` variable, and falls back to `~/.cache` if unset.

This PR makes the cache for all applications live in one single location, rather that littering the user's home.

Fixes #205

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.