### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+amazon-ecr-credential-helper (0.3.1-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Mon, 04 May 2020 18:33:54 +0000
+
 amazon-ecr-credential-helper (0.3.1-1) unstable; urgency=low
 
   [ Noah Meyerhans ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ amazon-ecr-credential-helper (0.3.1-2) UNRELEASED; urgency=medium
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
   * Add debian/watch file, using github.
+  * Use canonical URL in Vcs-Git.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 04 May 2020 18:33:54 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ amazon-ecr-credential-helper (0.3.1-2) UNRELEASED; urgency=medium
     Repository-Browse.
   * Add debian/watch file, using github.
   * Use canonical URL in Vcs-Git.
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 04 May 2020 18:33:54 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ amazon-ecr-credential-helper (0.3.1-2) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Add debian/watch file, using github.
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 04 May 2020 18:33:54 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Build-Depends:
 Standards-Version: 4.4.1
 Homepage: https://github.com/awslabs/amazon-ecr-credential-helper
 Vcs-Browser: https://github.com/awslabs/amazon-ecr-credential-helper
-Vcs-Git: https://github.com/awslabs/amazon-ecr-credential-helper
+Vcs-Git: https://github.com/awslabs/amazon-ecr-credential-helper.git
 XS-Go-Import-Path: github.com/awslabs/amazon-ecr-credential-helper
 
 Package: amazon-ecr-credential-helper

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Build-Depends:
  golang-github-sirupsen-logrus-dev,
  golang-github-golang-mock-dev,
  golang-github-pkg-errors-dev
-Standards-Version: 4.4.1
+Standards-Version: 4.5.0
 Homepage: https://github.com/awslabs/amazon-ecr-credential-helper
 Vcs-Browser: https://github.com/awslabs/amazon-ecr-credential-helper
 Vcs-Git: https://github.com/awslabs/amazon-ecr-credential-helper.git

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,2 +1,5 @@
-Repository: https://github.com/awslabs/amazon-ecr-credential-helper
+Bug-Database: https://github.com/awslabs/amazon-ecr-credential-helper/issues
+Bug-Submit: https://github.com/awslabs/amazon-ecr-credential-helper/issues/new
+Repository: https://github.com/awslabs/amazon-ecr-credential-helper.git
+Repository-Browse: https://github.com/awslabs/amazon-ecr-credential-helper
 Security-Contact: aws-security@amazon.com

--- a/debian/watch
+++ b/debian/watch
@@ -1,0 +1,2 @@
+version=4
+opts=filenamemangle=s/.*\/v(\d\S+)\.tar\.gz/amazon-ecr-credential-helper-$1\.tar\.gz/ https://github.com/awslabs/amazon-ecr-credential-helper/tags .*\/v(\d\S+)\.tar\.gz


### PR DESCRIPTION
Fix some issues reported by lintian
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Add debian/watch file, using github. ([debian-watch-file-is-missing](https://lintian.debian.org/tags/debian-watch-file-is-missing.html))
* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/amazon-ecr-credential-helper/5b87b4df-4eb5-49db-b973-5be9c8b23dc5.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Built-Using: golang-1.14 (= 1.14.2-1), golang-github-aws-aws-sdk-go (= 1.27.4+dfsg-1), golang-github-docker-docker-credential-helpers (= [-0.6.3-1),-] {+0.6.3-2~jan+lint1),+} golang-github-golang-mock (= [-1.3.1-2),-] {+1.0.0-2~jan+lint1),+} golang-github-jmespath-go-jmespath (= 0.3.0-1), golang-github-mitchellh-go-homedir (= [-1.1.0-1),-] {+1.1.0-2~jan+lint2),+} golang-github-pkg-errors (= 0.9.1-1), golang-golang-x-sys (= 0.0~git20200219.cb0a6d8-1), golang-logrus (= 1.5.0-1)


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/5b87b4df-4eb5-49db-b973-5be9c8b23dc5/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/5b87b4df-4eb5-49db-b973-5be9c8b23dc5/diffoscope)).
