### PR TITLE
debian: Install README.md to /usr/share/doc

### DIFF
--- a/debian/amazon-ecr-credential-helper.docs
+++ b/debian/amazon-ecr-credential-helper.docs
@@ -1,0 +1,1 @@
+README.md

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,14 @@
 amazon-ecr-credential-helper (0.3.1-2) UNRELEASED; urgency=medium
 
+  [ Debian Janitor ]
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
   * Add debian/watch file, using github.
   * Use canonical URL in Vcs-Git.
   * Update standards version to 4.5.0, no changes needed.
+
+  [ Noah Meyerhans ]
+  * Install README.md to /usr/share/doc (Closes: #962304)
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 04 May 2020 18:33:54 +0000
 


### PR DESCRIPTION
*Issue #, if available:*
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962304

*Description of changes:*
> As discussed outside the BTS, there is a man page, but its name corresponds with a binary that a user would never directly execute (it is run automatically by docker).  So it's not really clear which man page to consult to learn the proper configuration.  So, it would still be helpful to have README.md in place.
>
> Alternatively, symlinking the manual page to something more easily discoverable could help.  Since there's no binary named "amazon-ecr-credential-helper", it should not go in section 1.  Section 7 seems most appropriate.  But then the man page's header would be
wrong. (it'd still reference section 1)
>
> The attached patch will install README.md to the appropriate place.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
