### PR TITLE
Support AssumeRole when `credential_source = Environment`

### DIFF
--- a/ecr-login/api/factory.go
+++ b/ecr-login/api/factory.go
@@ -39,6 +39,7 @@ type ClientFactory interface {
 	NewClientWithOptions(opts Options) Client
 	NewClientFromRegion(region string) Client
 	NewClientWithFipsEndpoint(region string) (Client, error)
+	NewClientWithExplicitProfile(profile string) (Client, error)
 	NewClientWithDefaults() Client
 }
 
@@ -82,6 +83,23 @@ func (defaultClientFactory DefaultClientFactory) NewClientWithFipsEndpoint(regio
 		Session: awsSession,
 		Config:  awsConfig,
 	}), nil
+}
+
+// NewClientWithExplicitProfile creates a session with a custom profile set
+func (defaultClientFactory DefaultClientFactory) NewClientWithExplicitProfile(profile string) (Client, error) {
+       awsSession, err := session.NewSessionWithOptions(session.Options{
+               Profile: profile,
+               SharedConfigState: loadSharedConfigState(),
+       })
+       if err != nil {
+               return nil, err
+       }
+       awsSession.Handlers.Build.PushBackNamed(userAgentHandler)
+       awsConfig := awsSession.Config
+       return defaultClientFactory.NewClientWithOptions(Options{
+               Session: awsSession,
+               Config:  awsConfig,
+       }), nil
 }
 
 // NewClientFromRegion uses the region to create the client

--- a/ecr-login/mocks/ecr_mocks.go
+++ b/ecr-login/mocks/ecr_mocks.go
@@ -85,6 +85,17 @@ func (_mr *_MockClientFactoryRecorder) NewClientWithFipsEndpoint(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewClientWithFipsEndpoint", arg0)
 }
 
+func (_m *MockClientFactory) NewClientWithExplicitProfile(_param0 string) (api.Client, error) {
+	ret := _m.ctrl.Call(_m, "NewClientWithExplicitProfile", _param0)
+	ret0, _ := ret[0].(api.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockClientFactoryRecorder) NewClientWithExplicitProfile(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewClientWithExplicitProfile", arg0)
+}
+
 func (_m *MockClientFactory) NewClientWithOptions(_param0 api.Options) api.Client {
 	ret := _m.ctrl.Call(_m, "NewClientWithOptions", _param0)
 	ret0, _ := ret[0].(api.Client)


### PR DESCRIPTION
From #181 

*Description of changes:*
This PR is a slight variation on the code outlined in #181, which just always passes the value of `AWS_PROFILE` to the creation of a session. To the best of my knowledge, this will work in the regular cases which are already supported, as well as when assuming a role with `credential_source = Environment`.

I've not currently added any tests, because I cannot see any examples of tests which use the `~/.aws/config` or any tests which set `AWS_PROFILE`. 

Opening this for discussion and to hopefully arrive at a solution which is mergeable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
