### PR TITLE
README: Obvious string replacement for ECR URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ ECR registry:
 ```json
 {
 	"credHelpers": {
-		"aws_account_id.dkr.ecr.region.amazonaws.com": "ecr-login"
+		"<aws_account_id>.dkr.ecr.<region>.amazonaws.com": "ecr-login"
 	}
 }
 ```


### PR DESCRIPTION
*Description of changes:*
I ran into an issue with my coworkers today while onboarding our ECR environment where it wasn't obvious that the region needed to be set in their docker config.

We ended up with the failure mode that they had a literal `region` in their config instead of something like `us-east-1`.

I've wrapped the two things that need to be replaced with `<>`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
