### PR TITLE
debian: Update "Vcs-*" tags, fix d/watch, add testify to B-D

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -12,6 +12,7 @@ amazon-ecr-credential-helper (0.3.1-2) UNRELEASED; urgency=medium
 
   [ Tianon Gravi ]
   * Update "Vcs-*" tags to point to debian branch
+  * Update debian/watch to match the novendor tarballs
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 04 May 2020 18:33:54 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -13,6 +13,7 @@ amazon-ecr-credential-helper (0.3.1-2) UNRELEASED; urgency=medium
   [ Tianon Gravi ]
   * Update "Vcs-*" tags to point to debian branch
   * Update debian/watch to match the novendor tarballs
+  * Add "golang-github-stretchr-testify-dev" to B-D (Closes: #973063)
 
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 04 May 2020 18:33:54 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -10,6 +10,9 @@ amazon-ecr-credential-helper (0.3.1-2) UNRELEASED; urgency=medium
   [ Noah Meyerhans ]
   * Install README.md to /usr/share/doc (Closes: #962304)
 
+  [ Tianon Gravi ]
+  * Update "Vcs-*" tags to point to debian branch
+
  -- Debian Janitor <janitor@jelmer.uk>  Mon, 04 May 2020 18:33:54 +0000
 
 amazon-ecr-credential-helper (0.3.1-1) unstable; urgency=low

--- a/debian/control
+++ b/debian/control
@@ -15,8 +15,8 @@ Build-Depends:
  golang-github-pkg-errors-dev
 Standards-Version: 4.5.0
 Homepage: https://github.com/awslabs/amazon-ecr-credential-helper
-Vcs-Browser: https://github.com/awslabs/amazon-ecr-credential-helper
-Vcs-Git: https://github.com/awslabs/amazon-ecr-credential-helper.git
+Vcs-Browser: https://github.com/awslabs/amazon-ecr-credential-helper/tree/debian
+Vcs-Git: https://github.com/awslabs/amazon-ecr-credential-helper.git -b debian
 XS-Go-Import-Path: github.com/awslabs/amazon-ecr-credential-helper
 
 Package: amazon-ecr-credential-helper

--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Build-Depends:
  golang-github-docker-docker-credential-helpers-dev,
  golang-github-mitchellh-go-homedir-dev,
  golang-github-sirupsen-logrus-dev,
+ golang-github-stretchr-testify-dev,
  golang-github-golang-mock-dev,
  golang-github-pkg-errors-dev
 Standards-Version: 4.5.0

--- a/debian/watch
+++ b/debian/watch
@@ -1,2 +1,4 @@
 version=4
-opts=filenamemangle=s/.*\/v(\d\S+)\.tar\.gz/amazon-ecr-credential-helper-$1\.tar\.gz/ https://github.com/awslabs/amazon-ecr-credential-helper/tags .*\/v(\d\S+)\.tar\.gz
+opts=filenamemangle=s/.+\/(\d\S*)\/release-novendor\.tar\.gz/amazon-ecr-credential-helper_$1.orig.tar.gz/ \
+  https://github.com/awslabs/amazon-ecr-credential-helper/releases \
+  .*\/(\d\S+)/release-novendor\.tar\.gz


### PR DESCRIPTION
Per https://www.debian.org/doc/debian-policy/ch-controlfields.html#version-control-system-vcs-fields, `Vcs-*` are intended to point to the source of the packaging, which in this case is a little conflated because it's part of the upstream repo, but thankfully there is a provision for `Vcs-Git` to supply a branch name. :partying_face: 

(This should make it easier for folks to find the `debian/` directory in the future. :smile:)

Also, I've updated the Janitor's `debian/watch` file to properly download the `release-novendor.tar.gz` files from https://github.com/awslabs/amazon-ecr-credential-helper/releases (so that `uscan` does-the-right-thing).

As a final treat, I've added `golang-github-stretchr-testify-dev` to `Build-Depends`, which fixes https://bugs.debian.org/973063. :metal:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.