### PR TITLE
Drop Go 1.11 support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ['1.11', '1.12', '1.13', '1.14', '1.15']
+        go: ['1.12', '1.13', '1.14', '1.15']
 
         # Intentionally use specific versions instead of "latest" to
         # make this build reproducible.


### PR DESCRIPTION
This change removes Go 1.11 from GitHub Actions to unblock #253.

Go 1.11 doesn't work on macOS 10.05 after upgrading golang.org/x/sys.
While we could downgrade golang.org/x/sys, Go 1.11 is no longer
supported by the Go team and most OSes tend to have newer Go packages.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
