### PR TITLE
build: check for git dir when listing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: build
 SOURCEDIR=./ecr-login
 SOURCES := $(shell find $(SOURCEDIR) -name '*.go')
 VERSION := $(shell cat VERSION)
-GITFILES := $(shell find ".git/")
+GITFILES := $(shell test -d .git && find ".git/" -type f)
 BINARY_NAME=docker-credential-ecr-login
 LOCAL_BINARY=bin/local/$(BINARY_NAME)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The `Makefile` will reach into the `.git` directory without checking, causing an error to print from the `find` command run here. Instead, the shell can check for the directory first, and then list if present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
