### PR TITLE
version: rename default version

### DIFF
--- a/ecr-login/version/version.go
+++ b/ecr-login/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // Version indicates which version of the binary is running.
-var Version = "master"
+var Version = "development"
 
 // GitCommitSHA indicates which git shorthash the binary was built off of
 var GitCommitSHA string


### PR DESCRIPTION
The default version is used when this repository is built from source using a default `go build` command.  The primary development branch has been renamed from "master" to "main", but using the branch name as the version isn't super clear.  The new "development" default version makes it clear that the binary was built from source.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
