### PR TITLE
.github: switch branch from master to main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
Fixes the GitHub Actions workflow to make sure it runs on the new `main` branch.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
