### PR TITLE
Update aws-sdk-go to 1.38.44

### DIFF
--- a/ecr-login/go.mod
+++ b/ecr-login/go.mod
@@ -1,7 +1,7 @@
 module github.com/awslabs/amazon-ecr-credential-helper/ecr-login
 
 require (
-	github.com/aws/aws-sdk-go v1.37.32
+	github.com/aws/aws-sdk-go v1.38.44
 	github.com/docker/docker-credential-helpers v0.6.3
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/ecr-login/go.sum
+++ b/ecr-login/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go v1.37.32 h1:gLEASuX1phzqb00APUZU/xVIqf13IoA250RlgQ9rz28=
-github.com/aws/aws-sdk-go v1.37.32/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.38.44 h1:4JI2x15bwtiVP7VRRLBEm5dgbMVaR4HS1SES9BmBp5I=
+github.com/aws/aws-sdk-go v1.38.44/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I want to get the fix for aws/aws-sdk-go#3763 which is in 1.38.42 so I
can use an aws profile that has both sso and `credential_process`
configuration in a single profile


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
