### PR TITLE
README: add MacPorts instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ A community-maintained Homebrew formula is available in the core tap.
 $ brew install docker-credential-helper-ecr
 ```
 
+On macOS, another community-maintained installation method is to use MacPorts.
+
+[![MacPorts package](https://repology.org/badge/version-for-repo/macports/amazon-ecr-credential-helper.svg)](https://repology.org/project/amazon-ecr-credential-helper/versions)
+
+```bash
+$ sudo port install docker-credential-helper-ecr
+```
+
 Once you have installed the credential helper, see the
 [Configuration section](#Configuration) for instructions on how to configure
 Docker to work with the helper.


### PR DESCRIPTION
*Description of changes:*
Adds instructions on installing `amazon-ecr-credential-helper` via MacPorts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
