### PR TITLE
Update Go versions on GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ['1.12', '1.13', '1.14', '1.15']
+        go: ['1.13', '1.14', '1.15', '1.16']
 
         # Intentionally use specific versions instead of "latest" to
         # make this build reproducible.


### PR DESCRIPTION
Go 1.12 is no longer supported by the Go team and AWS SDK v2
(technically speaking github.com/aws/smithy-go) doesn work with
the version.

Go 1.16 is the latest version, released in 2021-02-16.

https://blog.golang.org/go1.16

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
