### PR TITLE
Update go command to account for deprecation of go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ setx GOPATH %USERPROFILE%\go
 If you haven't defined the PATH, the command below will fail silently, and
 running `docker-credential-ecr-login` will output: `command not found`
 
-You can install this via `go get` with:
+You can install this via `go install` with:
 
 ```
 go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@latest

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ running `docker-credential-ecr-login` will output: `command not found`
 You can install this via `go get` with:
 
 ```
-go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
+go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@latest
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -123,12 +123,19 @@ setx GOPATH %USERPROFILE%\go
 If you haven't defined the PATH, the command below will fail silently, and
 running `docker-credential-ecr-login` will output: `command not found`
 
-You can install this via `go install` with:
+You can install this via the `go` command line tool.
+
+For go version 1.16 and newer run :
 
 ```
 go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@latest
 ```
 
+or with an older version of go run :
+
+```
+go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
+```
 
 If you already have Docker environment, just clone this repository anywhere
 and run `make docker`. This command builds the binary with Go inside the Docker


### PR DESCRIPTION
This changes the README's `go get` to `go install` as `go get` is deprecated and now returns
```
go get: installing executables with 'go get' in module mode is deprecated.
```

https://golang.org/doc/go-get-install-deprecation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
