### PR TITLE
Add go build flags to ensure reproducible builds

### DIFF
--- a/scripts/build_binary.sh
+++ b/scripts/build_binary.sh
@@ -35,6 +35,10 @@ if [[ -n "${3}" ]]; then
 fi
 
 GOOS=${TARGET_GOOS:-} GOARCH=${TARGET_GOARCH:-} CGO_ENABLED=0 \
-       	go build -installsuffix cgo -a -ldflags "-s ${version_ldflags}" \
+       	go build \
+       	-installsuffix cgo \
+       	-a \
+       	-ldflags "-buildid= -s ${version_ldflags}" \
+       	-trimpath \
        	-o ../$1/docker-credential-ecr-login \
 	./cli/docker-credential-ecr-login


### PR DESCRIPTION
*Issue #, if available:*
 Produce reproducible builds #186 

*Description of changes:*
Adds `-trimpath` to remove local paths from executable and sets build id to empty string using `-ldflags=-buildid=`. Both flags are required for reproducible builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
