### PR TITLE
Allow callers to set log output

### DIFF
--- a/ecr-login/cli/docker-credential-ecr-login/main.go
+++ b/ecr-login/cli/docker-credential-ecr-login/main.go
@@ -19,7 +19,6 @@ import (
 	"os"
 
 	ecr "github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
-	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api"
 	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login/config"
 	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login/version"
 	"github.com/docker/docker-credential-helpers/credentials"
@@ -42,5 +41,5 @@ func main() {
 	}
 
 	config.SetupLogger()
-	credentials.Serve(ecr.ECRHelper{ClientFactory: api.DefaultClientFactory{}})
+	credentials.Serve(ecr.NewECRHelper())
 }

--- a/ecr-login/ecr_test.go
+++ b/ecr-login/ecr_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	ecr "github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api"
-	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login/mocks"
+	mock_api "github.com/awslabs/amazon-ecr-credential-helper/ecr-login/mocks"
 	"github.com/docker/docker-credential-helpers/credentials"
 	"github.com/stretchr/testify/assert"
 )
@@ -36,9 +36,7 @@ func TestGetSuccess(t *testing.T) {
 	factory := &mock_api.MockClientFactory{}
 	client := &mock_api.MockClient{}
 
-	helper := &ECRHelper{
-		ClientFactory: factory,
-	}
+	helper := NewECRHelper(WithClientFactory(factory))
 
 	factory.NewClientFromRegionFn = func(_ string) ecr.Client { return client }
 	client.GetCredentialsFn = func(serverURL string) (*ecr.Auth, error) {
@@ -62,9 +60,7 @@ func TestGetError(t *testing.T) {
 	factory := &mock_api.MockClientFactory{}
 	client := &mock_api.MockClient{}
 
-	helper := &ECRHelper{
-		ClientFactory: factory,
-	}
+	helper := NewECRHelper(WithClientFactory(factory))
 
 	factory.NewClientFromRegionFn = func(_ string) ecr.Client { return client }
 	client.GetCredentialsFn = func(serverURL string) (*ecr.Auth, error) {
@@ -78,7 +74,7 @@ func TestGetError(t *testing.T) {
 }
 
 func TestGetNoMatch(t *testing.T) {
-	helper := &ECRHelper{}
+	helper := NewECRHelper(WithClientFactory(nil))
 
 	username, password, err := helper.Get("not-ecr-server-url")
 	assert.True(t, credentials.IsErrCredentialsNotFound(err))
@@ -90,9 +86,7 @@ func TestListSuccess(t *testing.T) {
 	factory := &mock_api.MockClientFactory{}
 	client := &mock_api.MockClient{}
 
-	helper := &ECRHelper{
-		ClientFactory: factory,
-	}
+	helper := NewECRHelper(WithClientFactory(factory))
 
 	factory.NewClientWithDefaultsFn = func() ecr.Client { return client }
 	client.ListCredentialsFn = func() ([]*ecr.Auth, error) {
@@ -113,9 +107,7 @@ func TestListFailure(t *testing.T) {
 	factory := &mock_api.MockClientFactory{}
 	client := &mock_api.MockClient{}
 
-	helper := &ECRHelper{
-		ClientFactory: factory,
-	}
+	helper := NewECRHelper(WithClientFactory(factory))
 
 	factory.NewClientWithDefaultsFn = func() ecr.Client { return client }
 	client.ListCredentialsFn = func() ([]*ecr.Auth, error) {


### PR DESCRIPTION
Signed-off-by: Jason Hall <jasonhall@redhat.com>

*Description of changes:*

Though this code is typically consumed as a CLI cred helper configured for use with the `docker` CLI, we've also found it to be really useful as a Go client for generating ECR credentials from the environment.

[`go-containerregistry`](https://github.com/google/go-containerregistry), which is used by [Tekton](https://tekton.dev), [Knative](https://knative.dev), [`ko`](https://github.com/google/ko), [`cosign`](https://github.com/sigstore/cosign), [Kaniko](https://kaniko.dev), [Buildpacks](https://buildpacks.io) and more, provides an adapter between its auth-providing [`authn.Keychain`](https://godoc.org/github.com/google/go-containerregistry/pkg/authn#Keychain) interface, and Docker's `credential.Helper` interface, which you implement here. This means that these tools can (and some already do!) embed the cred helper's logic with:

```go
kc := authn.NewKeychainFromHelper(ecr.ECRHelper{ClientFactory: api.DefaultClientFactory{}})
```

For example:
- https://github.com/google/ko/blob/89ede9110a1333a31bf417cb5fed6f69f8084ff1/pkg/commands/config.go#L45
- https://github.com/GoogleContainerTools/kaniko/blob/a7425d1fd0442b58dc24698285102176365a28d9/pkg/creds/creds.go#L32
- https://github.com/sigstore/cosign/blob/22007e56aee419ae361c9f021869a30e9ae7be03/cmd/cosign/cli/options/registry.go#L78

And this works great! 🎉  These clients don't have to install the cred helper CLI and configure it using `~/.docker/config.json` to pick up any available ECR credentials; they Just Work™️.

Except...

Through this usage, this library logs a harmless error when we check whether a particular possibly-non-ECR registry can be used with this code. In its normal CLI usage, `docker` won't invoke the ecr-login cred helper unless it already knows the registry is ECR, so this logging is correct in identifying a weird situation. But in usage as a library, this leads to spammy, sometimes scary log messages, which we'd like to avoid.

I tried all manner of terrible hacks to disable `os.Stderr`, but due to how logrus works internally, and how this code uses it, it doesn't seem possible without making logrus-specific changes to all those downstream clients.

Instead, this PR proposes adding a func that's unused by the CLI code (its logic remains unchanged), to let library consumers set the log output for the scope of ecr-login's usage, which downstream clients can set to `ioutil.Discard` if they want. This is quite a bit less invasive than any alternative I came up with, and should impose almost no maintenance burden to you lovely maintainers ❤️ 

This also slightly changes the API for instantiating an `ECRHelper` using `NewECRHelper()`, though AFAIK the CLI (and our users, whom I'll happily update) depends on that directly.