### PR TITLE
Optionally ignore docker's request for storing / deleting credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Docker to work with the helper.
 To build and install the Amazon ECR Docker Credential Helper, we suggest Go
 1.19 or later, `git` and `make` installed on your system.
 
-If you just installed Go, make sure you also have added it to your PATH or 
+If you just installed Go, make sure you also have added it to your PATH or
 Environment Vars (Windows). For example:
 
 ```
@@ -213,7 +213,7 @@ include:
 * An [IAM role for Amazon EC2](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
 
 To use credentials associated with a different named profile in the shared credentials file (`~/.aws/credentials`), you
-may set the `AWS_PROFILE` environment variable. 
+may set the `AWS_PROFILE` environment variable.
 
 The Amazon ECR Docker Credential Helper reads and supports some configuration options specified in the AWS
 shared configuration file (`~/.aws/config`).  To disable these options, you must set the `AWS_SDK_LOAD_CONFIG` environment
@@ -236,12 +236,13 @@ in the *AWS Command Line Interface User Guide*.
 The credentials must have a policy applied that
 [allows access to Amazon ECR](http://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr_managed_policies.html).
 
-### Amazon ECR Docker Credential Helper 
+### Amazon ECR Docker Credential Helper
 
-| Environment Variable  | Sample Value  | Description                                                        |
-| --------------------- | ------------- | ------------------------------------------------------------------ |
-| AWS_ECR_DISABLE_CACHE | true          | Disables the local file auth cache if set to a non-empty value     |
-| AWS_ECR_CACHE_DIR     | ~/.ecr        | Specifies the local file auth cache directory location             |
+| Environment Variable         | Sample Value  | Description                                                        |
+| ---------------------------- | ------------- | ------------------------------------------------------------------ |
+| AWS_ECR_DISABLE_CACHE        | true          | Disables the local file auth cache if set to a non-empty value     |
+| AWS_ECR_CACHE_DIR            | ~/.ecr        | Specifies the local file auth cache directory location             |
+| AWS_ECR_IGNORE_CREDS_STORAGE | true          | Ignore calls to docker login or logout and pretend they succeeded  |
 
 ## Usage
 

--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -73,8 +73,8 @@ var _ credentials.Helper = (*ECRHelper)(nil)
 func (self ECRHelper) Add(creds *credentials.Credentials) error {
 	self.logger.Warningf(
 		"Ignoring request to store credentials for %s@%s. "+
-			"This is not supported in the context of the docker ecr-login helper."+
-			creds.Username,
+			"This is not supported in the context of the docker ecr-login helper.",
+		creds.Username,
 		creds.ServerURL)
 	return nil
 }

--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -71,11 +71,11 @@ var _ credentials.Helper = (*ECRHelper)(nil)
 // storing arbitrary user given credentials makes no sense. To keep interoperability with applications that call `docker
 // login` during their execution, this is implemented as a nop.
 func (self ECRHelper) Add(creds *credentials.Credentials) error {
-	self.logger.Warningf(
-		"Ignoring request to store credentials for %s@%s. "+
-			"This is not supported in the context of the docker ecr-login helper.",
-		creds.Username,
-		creds.ServerURL)
+	self.logger.
+		WithField("username", creds.Username).
+		WithField("serverURL", creds.ServerURL).
+		Warning("Ignoring request to store credentials. " +
+			"This is not supported in the context of the docker ecr-login helper.")
 	return nil
 }
 
@@ -83,10 +83,10 @@ func (self ECRHelper) Add(creds *credentials.Credentials) error {
 // don't store arbitrary user given credentials so deleting them makes no sense. To keep interoperability with
 // applications that call `docker logout` during their execution, this is implemented as a nop.
 func (self ECRHelper) Delete(serverURL string) error {
-	self.logger.Warningf(
-		"Ignoring request to delete credentials for %s. "+
-			"This is not supported in the context of the docker ecr-login helper.",
-		serverURL)
+	self.logger.
+		WithField("serverURL", serverURL).
+		Warning("Ignoring request to delete credentials. " +
+			"This is not supported in the context of the docker ecr-login helper.")
 	return nil
 }
 

--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -75,7 +75,7 @@ func shouldIgnoreCredsStorage() bool {
 	return os.Getenv("AWS_ECR_IGNORE_CREDS_STORAGE") == "true"
 }
 
-// Called when docker tries to store credentials. This usually happens during `docker login` calls. In our context,
+// Add tries to store credentials when docker requests it. This usually happens during `docker login` calls. In our context,
 // storing arbitrary user given credentials makes no sense.
 func (self ECRHelper) Add(creds *credentials.Credentials) error {
 	if shouldIgnoreCredsStorage() {
@@ -90,7 +90,7 @@ func (self ECRHelper) Add(creds *credentials.Credentials) error {
 	}
 }
 
-// Called when docker tries to delete credentials. This usually happens during `docker logout` calls. In our context, we
+// Delete tries to delete credentials when docker requests it. This usually happens during `docker logout` calls. In our context, we
 // don't store arbitrary user given credentials so deleting them makes no sense.
 func (self ECRHelper) Delete(serverURL string) error {
 	if shouldIgnoreCredsStorage() {

--- a/ecr-login/ecr_test.go
+++ b/ecr-login/ecr_test.go
@@ -118,3 +118,27 @@ func TestListFailure(t *testing.T) {
 	assert.Error(t, err)
 	assert.Len(t, serverList, 0)
 }
+
+func TestAddNop(t *testing.T) {
+	factory := &mock_api.MockClientFactory{}
+
+	helper := NewECRHelper(WithClientFactory(factory))
+
+	err := helper.Add(&credentials.Credentials{
+		ServerURL: "123456789.dkr.ecr.us-east-1.amazonaws.com",
+		Username:  "AWS",
+		Secret:    "supersecret",
+	})
+
+	assert.Nil(t, err)
+}
+
+func TestDeleteNop(t *testing.T) {
+	factory := &mock_api.MockClientFactory{}
+
+	helper := NewECRHelper(WithClientFactory(factory))
+
+	err := helper.Delete("123456789.dkr.ecr.us-east-1.amazonaws.com")
+
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
*Issue #, if available:* #102 & #154

*Description of changes:*

Currently, both the `Add` and `Delete` operations in this helper return a `not implemented` error. This can lead to issues where `docker login` and `docker logout` stop working for the user while displaying a confusing `not implemented` error.

Following the suggestion in https://github.com/awslabs/amazon-ecr-credential-helper/issues/154#issuecomment-475000495, this PR adds an environment variable (`AWS_ECR_IGNORE_CREDS_STORAGE`) to optionally ignore these requests and return no error. When `AWS_ECR_IGNORE_CREDS_STORAGE=true`, instead of returning a `not implemented` error, we return `nil`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
