### PR TITLE
Don't require amazonaws.com in ECR url pattern

### DIFF
--- a/ecr-login/api/client.go
+++ b/ecr-login/api/client.go
@@ -37,7 +37,7 @@ const (
 	ecrPublicEndpoint   = proxyEndpointScheme + ecrPublicName
 )
 
-var ecrPattern = regexp.MustCompile(`(^[a-zA-Z0-9][a-zA-Z0-9-_]*)\.dkr\.ecr(-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.amazonaws\.com(\.cn)?$`)
+var ecrPattern = regexp.MustCompile(`(^[a-zA-Z0-9][a-zA-Z0-9-_]*)\.dkr\.ecr(-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*).+$`)
 
 type Service string
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Some deployments of AWS are served behind a proxy or have an alternative domain name. The current code checks for `amazonaws.com` in the domain name when it gets matches via the regex (see https://github.com/awslabs/amazon-ecr-credential-helper/blob/main/ecr-login/api/client.go#L40). The domain name does not appear to be used in the matches argument and could be removed to enable using this against proxy, alternative, or iso region deployments of AWS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
