### PR TITLE
Recommend Go 1.15 or later

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ['1.13', '1.14', '1.15', '1.16']
+        go: ['1.15', '1.16', '1.17', '1.18']
 
         # Intentionally use specific versions instead of "latest" to
         # make this build reproducible.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - run: make get-deps
+        if: ${{ matrix.go >= '1.17' }}
 
       # Apple Silicon is not supported by Go < 1.16.
       # https://go.dev/blog/go1.16

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-FROM golang:1.13
+FROM golang:1.15
 
 WORKDIR /go/src/github.com/awslabs/amazon-ecr-credential-helper
 

--- a/Makefile
+++ b/Makefile
@@ -102,9 +102,7 @@ gogenerate:
 
 .PHONY: get-deps
 get-deps:
-	go get github.com/tools/godep
-	go get golang.org/x/tools/cmd/cover
-	go get golang.org/x/tools/cmd/goimports
+	go install golang.org/x/tools/cmd/goimports@698251aaa532d49ac69d2c416b0241afb2f65ea5
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Docker to work with the helper.
 
 ### From Source
 To build and install the Amazon ECR Docker Credential Helper, we suggest Go
-1.12+, `git` and `make` installed on your system.
+1.15 or later, `git` and `make` installed on your system.
 
 If you just installed Go, make sure you also have added it to your PATH or 
 Environment Vars (Windows). For example:


### PR DESCRIPTION
Go 1.13 is no longer supported by the Go team and AWS SDK for Go requires
Go 1.15.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
