### PR TITLE
Fix Missing build-id issue during rpm build

### DIFF
--- a/Makefile.amazonlinux
+++ b/Makefile.amazonlinux
@@ -27,7 +27,7 @@ srpm: .srpm-done
 .rpm-done: release.tar.gz
 	test -e SOURCES || ln -s . SOURCES
 	chown ${UID}.${UID} SOURCES/release.tar.gz
-	rpmbuild --define "%_topdir $(PWD)" -bb amazon-ecr-credential-helper.spec
+	rpmbuild --define "%_topdir $(PWD)" -D 'debug_package %{nil}' -bb amazon-ecr-credential-helper.spec
 	find RPMS/ -type f -exec cp {} . \;
 	touch .rpm-done
 

--- a/scripts/build_binary.sh
+++ b/scripts/build_binary.sh
@@ -35,6 +35,10 @@ if [[ -n "${3}" ]]; then
 fi
 
 GOOS=${TARGET_GOOS:-} GOARCH=${TARGET_GOARCH:-} CGO_ENABLED=0 \
-       	go build -installsuffix cgo -a -ldflags "-s ${version_ldflags}" \
-       	-o ../$1/docker-credential-ecr-login \
-	./cli/docker-credential-ecr-login
+        go build \
+        -installsuffix cgo \
+        -a \
+        -ldflags "-buildid= -s ${version_ldflags}" \
+        -trimpath \
+        -o ../$1/docker-credential-ecr-login \
+        ./cli/docker-credential-ecr-login


### PR DESCRIPTION
Pass --buildid as ldflag otherwise rpmbuild fails. Golang compiler adds its own build-id into the binary, named .note.go.build-id. However, rpmbuild wants Fedora compatible build-id, in the format note.gnu.build-id.

Signed-off-by: Swagat Bora <sbora@amazon.com>

*Issue #, if available:* https://t.corp.amazon.com/P68468819

*Description of changes:*
Saw that the `main` branch is already passing the `buildid` ldflag, which was missing in the `amazonlinux` branch. This was causing rpmbuild to fail. There was another issue which I believe is caused due to stripping on symbol table while the binaries were built. This was fixed by passing -D 'debug_package %{nil}` during rpmbuild

```
RPM build errors:
    Empty %files file /home/ec2-user/amazon-ecr-credential-helper/BUILD/amazon-ecr-credential-helper-0.6.0/debugsourcefiles.list
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
