### PR TITLE
Disable debug package rpm build for AL2022

### DIFF
--- a/Makefile.amazonlinux
+++ b/Makefile.amazonlinux
@@ -27,7 +27,7 @@ srpm: .srpm-done
 .rpm-done: release.tar.gz
 	test -e SOURCES || ln -s . SOURCES
 	chown ${UID}.${UID} SOURCES/release.tar.gz
-	rpmbuild --define "%_topdir $(PWD)" -D 'debug_package %{nil}' -bb amazon-ecr-credential-helper.spec
+	rpmbuild --define "%_topdir $(PWD)" -bb amazon-ecr-credential-helper.spec
 	find RPMS/ -type f -exec cp {} . \;
 	touch .rpm-done
 

--- a/amazon-ecr-credential-helper.spec
+++ b/amazon-ecr-credential-helper.spec
@@ -11,6 +11,9 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and
 # limitations under the License.
+%if 0%{?amzn} > 2
+%define debug_package %{nil}
+%endif
 Name:           amazon-ecr-credential-helper
 Version:        0.6.0
 Release:        1%{?dist}


### PR DESCRIPTION
Signed-off-by: Swagat Bora <sbora@amazon.com>

*Issue #, if available:* 

*Description of changes:* Al2022 rpmbuild is seeing failure whille trying to build debuginfo package. Earlier, we disabled debug build in our Makefile.amazonlinux in `make rpm` target. However, Koji builds calls rpmbuild directly and tries to build debug package. 

As a result, now we have updated the .spec file itself to disable debug build if building for AL2022. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
