### PR TITLE
correct docker config instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ contents of your `~/.docker/config.json` file to be:
 
 ```json
 {
-	"credsStore": "ecr-login"
+	"credStore": "ecr-login"
 }
 ```
 This configures the Docker daemon to use the credential helper for all Amazon


### PR DESCRIPTION
*Issue #, if available:*
Ubuntu 18.04
Docker version 20.10.17, build 100c701

After following the instructions to compile from Source, the command was still not working.
I had to change the docker/config.json as below.
It seems that I am not the only person with this problem
https://stackoverflow.com/questions/67642620/docker-credential-desktop-not-installed-or-not-available-in-path

*Description of changes:*
Changed readme

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
