### PR TITLE
Add Amazon Linux 2023 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,18 @@ use different AWS credentials.
 
 ## Installing
 
-### Amazon Linux 2
+### Amazon Linux 2023 (AL2023)
+You can install the Amazon ECR Credential Helper from the Amazon Linux 2023 repositories.
+
+```bash
+$ sudo dnf install -y amazon-ecr-credential-helper
+```
+
+Once you have installed the credential helper, see the
+[Configuration section](#Configuration) for instructions on how to configure
+Docker to work with the helper.
+
+### Amazon Linux 2 (AL2)
 You can install the Amazon ECR Credential Helper from the [`docker` or `ecs`
 extras](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-linux-ami-basics.html#extras-library).
 


### PR DESCRIPTION
*Description of changes:*
Add Amazon Linux 2023 to the Install section, as `amazon-ecr-credential-helper` is available in the AL2023 repositories.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
