### PR TITLE
fix `not implemented` errors

### DIFF
--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -71,13 +71,13 @@ func NewECRHelper(opts ...Option) *ECRHelper {
 var _ credentials.Helper = (*ECRHelper)(nil)
 
 func (ECRHelper) Add(creds *credentials.Credentials) error {
-	// This does not seem to get called
-	return notImplemented
+	// Never store the credentials
+	return nil
 }
 
 func (ECRHelper) Delete(serverURL string) error {
-	// This does not seem to get called
-	return notImplemented
+	// Never store the credentials
+	return nil
 }
 
 func (self ECRHelper) Get(serverURL string) (string, string, error) {


### PR DESCRIPTION
*Issue #, if available:*
Closes https://github.com/awslabs/amazon-ecr-credential-helper/issues/574
Closes https://github.com/awslabs/amazon-ecr-credential-helper/issues/474
Closes https://github.com/awslabs/amazon-ecr-credential-helper/issues/316

*Description of changes:*
The current code assumes some methods are not called, which is no longer true.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
