### PR TITLE
fix: upgrade Dockerfile to go 1.19

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,13 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - run: make get-deps
-        if: ${{ matrix.go >= '1.17' }}
+        if: ${{ matrix.go >= '1.19' }}
+
+      # test Dockerfile build on Linux. macOS runners do not ship with Docker
+      # installed by default whereas Ubuntu runners do.
+      - name: Build in Dockerfile
+        run: make docker
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
 
       # Apple Silicon is not supported by Go < 1.16.
       # https://go.dev/blog/go1.16

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-FROM golang:1.15
+FROM golang:1.19
 
 WORKDIR /go/src/github.com/awslabs/amazon-ecr-credential-helper
 


### PR DESCRIPTION
*Issue #, if available:*

Fixes #579 

*Description of changes:*

outdated version of Go in Dockerfile resulted in build failures. Add step in CI to build in Dockerfile for future regressions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
