### PR TITLE
Add Go 1.21 to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ['1.19', '1.20']
+        go: ['1.19', '1.20', '1.21']
 
         # Intentionally use specific versions instead of "latest" to
         # make this build reproducible.


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Go 1.21 is released. This PR adds support to the CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
