### PR TITLE
Fixes #432, override docker-credential-helpers version fields

### DIFF
--- a/ecr-login/cli/docker-credential-ecr-login/main.go
+++ b/ecr-login/cli/docker-credential-ecr-login/main.go
@@ -29,6 +29,14 @@ Version:    %s
 Git commit: %s
 `
 
+func init() {
+	// Set up version information in docker-credential-helpers package
+	credentials.Name = "docker-credential-ecr-login"
+	credentials.Package = "github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
+	credentials.Version = version.Version
+	credentials.Revision = version.GitCommitSHA
+}
+
 func main() {
 	var versionFlag bool
 	flag.BoolVar(&versionFlag, "v", false, "print version and exit")


### PR DESCRIPTION
Fixes #432: Release version inconsistent with docker-credential-ecr-login version 

*Description of changes:*

During build, override the name/package/version/revision fields defined in [docker-credential-helpers/blob/master/credentials/version.go](https://github.com/docker/docker-credential-helpers/blob/master/credentials/version.go)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
