### PR TITLE
Enable git secrets scanning in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,25 @@ on:
     branches: [ main ]
 
 jobs:
+  git-secrets:
+    runs-on: 'ubuntu-22.04'
+    steps:
+      - name: Pull latest awslabs/git-secrets repo
+        uses: actions/checkout@v4
+        with:
+          repository: awslabs/git-secrets
+          ref: 1.3.0
+          fetch-tags: true
+          path: git-secrets
+      - name: Install git secrets from source
+        run: sudo make install
+        working-directory: git-secrets
+      - uses: actions/checkout@v4
+      - name: Scan repository for git secrets
+        run: |
+          git secrets --register-aws
+          git secrets --scan-history
+
   build:
     strategy:
       matrix:


### PR DESCRIPTION
*Issue #, if available:*
Contributors can accidentally submit git secrets to version control.

*Description of changes:*
This change enables git secrets in CI to prevent sensitive information being contributed to version control.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
