### PR TITLE
Add Windows 2022 x86 to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
 
         # Intentionally use specific versions instead of "latest" to
         # make this build reproducible.
-        os: ['ubuntu-22.04', 'macos-12']
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
 
       # Build all variants regardless of failures
       fail-fast: false


### PR DESCRIPTION
*Issue #, if available:*
Amazon ECR credential helper is released for Windows x86; however, we lack basic test coverage on this platform in CI.

*Description of changes:*
This change adds Windows 2022 x86 to CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
