### PR TITLE
Add windows to ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
 
         # Intentionally use specific versions instead of "latest" to
         # make this build reproducible.
-        os: ['ubuntu-22.04', 'macos-12']
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
 
       # Build all variants regardless of failures
       fail-fast: false


### PR DESCRIPTION
*Issue #, if available:*
Closes #790 

There is a lack of coverage for the Windows platform in CI.

*Description of changes:*
This change adds Windows unit testing to GitHub Actions CI matrix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
