### PR TITLE
Add disclaimer for container image support to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ To install run:
 go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@latest
 ```
 
+> [!WARNING]
+> Disclaimer: the [Dockerfile](./Dockerfile) in this repository is used to test cross-compilation of the
+> Amazon ECR credential helper binaries in GitHub Actions CI and as a developer utility for building locally from source.
+> It is a reference implementation and not security hardened for building and running production containers.
+
 If you already have Docker environment, just clone this repository anywhere
 and run `make build-in-docker`. This command builds the binary with Go inside the Docker
 container and output it to local directory.


### PR DESCRIPTION
*Issue #, if available:*
Clarify the support model for the Dockerfile included in the Amazon ECR credential helper repository.

*Description of changes:*
This change adds a disclaimer regarding the support of the Dockerfile provided for cross compiling the Amazon ECR credential helper binaries and locally building from source using Docker.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
