### PR TITLE
Add awslabs to git safe dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ WINDOWS_ARM64_BINARY=$(BINPATH)/windows-arm64/$(BINARY_NAME).exe
 .PHONY: docker
 docker: build-in-docker
 
-%-in-docker:
+%-in-docker: GITCOMMIT_SHA
 	docker run --rm \
 		--user $(UID):$(GID) \
 		--env TARGET_GOOS=$(TARGET_GOOS) \

--- a/scripts/container_init.sh
+++ b/scripts/container_init.sh
@@ -27,4 +27,5 @@ apk add --no-cache \
 # Resolves permission issues for Go cache when
 # building credential helper as non-root user.
 mkdir /.cache && chmod 777 /.cache
+git config --global --add safe.directory /go/src/github.com/awslabs/amazon-ecr-credential-helper
 

--- a/scripts/container_init.sh
+++ b/scripts/container_init.sh
@@ -27,5 +27,7 @@ apk add --no-cache \
 # Resolves permission issues for Go cache when
 # building credential helper as non-root user.
 mkdir /.cache && chmod 777 /.cache
+# Resolves dubious ownership of git directory when
+# building credential helper as root user.
 git config --global --add safe.directory /go/src/github.com/awslabs/amazon-ecr-credential-helper
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes the following error when running `make build-in-docker` for ISSUE: https://github.com/awslabs/amazon-ecr-credential-helper/issues/800
```
git rev-parse --short=7 HEAD > GITCOMMIT_SHA
fatal: detected dubious ownership in repository at '/go/src/github.com/awslabs/amazon-ecr-credential-helper'
To add an exception for this directory, call:

        git config --global --add safe.directory /go/src/github.com/awslabs/amazon-ecr-credential-helper
make: *** [Makefile:95: GITCOMMIT_SHA] Error 128
```

*Description of changes:*
- Adds `/go/src/github.com/awslabs/amazon-ecr-credential-helper` to git as a safe directory. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
