### PR TITLE
Use set and forget copyrights

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Amazon ECR Credential Helper
-Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. 

--- a/docs/docker-credential-ecr-login.1
+++ b/docs/docker-credential-ecr-login.1
@@ -1,4 +1,4 @@
-.\" Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+.\" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 .\"
 .\" Licensed under the Apache License, Version 2.0 (the
 .\" "License"). You may not use this file except in compliance
@@ -111,7 +111,7 @@ user may encounter permission issues described here:
 https://github.com/kubernetes-sigs/external-dns/pull/1185.  You may be able to
 work around this bug by adjusting the Kubernetes \fIsecurityContext\fP.
 .SH COPYRIGHT
-Copyright 2018-2020 Amazon.com, Inc. or its affiliates.  All rights reserved.
+Copyright Amazon.com, Inc. or its affiliates.  All rights reserved.
 .SH LICENSE
 Licensed under the Apache License, version 2.0.
 

--- a/ecr-login/api/client.go
+++ b/ecr-login/api/client.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/api/client_test.go
+++ b/ecr-login/api/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -69,7 +69,7 @@ func TestExtractRegistry(t *testing.T) {
 			Service: ServiceECR,
 		},
 		hasError: false,
-        }, {
+	}, {
 		serverURL: "210987654321.dkr.ecr.us-iso-east-1.c2s.ic.gov",
 		registry: &Registry{
 			ID:      "210987654321",

--- a/ecr-login/api/factory.go
+++ b/ecr-login/api/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/api/mocks/api_mocks.go
+++ b/ecr-login/api/mocks/api_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/cache/build.go
+++ b/ecr-login/cache/build.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/cache/build_test.go
+++ b/ecr-login/cache/build_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/cache/credentials.go
+++ b/ecr-login/cache/credentials.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/cache/credentials_test.go
+++ b/ecr-login/cache/credentials_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/cache/file.go
+++ b/ecr-login/cache/file.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/cache/file_test.go
+++ b/ecr-login/cache/file_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/cache/mocks/cache_mocks.go
+++ b/ecr-login/cache/mocks/cache_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/cache/null.go
+++ b/ecr-login/cache/null.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/cache/null_test.go
+++ b/ecr-login/cache/null_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/cli/docker-credential-ecr-login/main.go
+++ b/ecr-login/cli/docker-credential-ecr-login/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/config/cache_dir.go
+++ b/ecr-login/config/cache_dir.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/config/log.go
+++ b/ecr-login/config/log.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/ecr_test.go
+++ b/ecr-login/ecr_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecr-login/mocks/ecr_mocks.go
+++ b/ecr-login/mocks/ecr_mocks.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/scripts/build_binary.sh
+++ b/scripts/build_binary.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/scripts/build_variant.sh
+++ b/scripts/build_variant.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/scripts/container_init.sh
+++ b/scripts/container_init.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of

--- a/scripts/gogenerate
+++ b/scripts/gogenerate
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the

--- a/scripts/hack/codepipeline-git-commit.sh
+++ b/scripts/hack/codepipeline-git-commit.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the

--- a/scripts/hack/codepipeline-source-archive.sh
+++ b/scripts/hack/codepipeline-source-archive.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the

--- a/scripts/hack/symlink-gopath-codebuild.sh
+++ b/scripts/hack/symlink-gopath-codebuild.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the

--- a/scripts/hack/version-changelog.sh
+++ b/scripts/hack/version-changelog.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may
 # not use this file except in compliance with the License. A copy of the


### PR DESCRIPTION
*Issue #, if available:*
The copyright dates for the source code are not being updated when they should.

*Description of changes:*
This change updates the Amazon developed open source code to switch to dateless copyrights. This removes the time and headache for updating the dates each year as the relevant code changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
