### PR TITLE
Group updates to aws/aws-sdk-go-v2 dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     directory: "/ecr-login"
     schedule:
       interval: "daily"
+    groups:
+      # Group updates from github.com/aws/aws-sdk-go-v2 dependencies
+      aws-sdk-go-v2:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2/*"
 
   # Dependencies listed in .github/workflows/*.yml
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
*Issue #, if available:*
The Amazon ECR credential helper depends on multiple modules from the AWS SDK Go v2 project and is automated pull requests are frequently made to keep the packages up-to-date. The problem is some of the modules depend on each other and must be applied in a specific order to truly be considered atomic updates. This is difficult to maintain and an alternative consideration is to group all the AWS SDK updates into a single commit to simplify maintenance of the updates.

*Description of changes:*
This change adds dependabot configuration to group updates to aws/aws-sdk-go-v2 dependencies. The v2 of the Go SDK distributes multiple modules required by the Amazon ECR credential helper. This will reduce the effort required to keep the dependencies up-to-date.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
