### PR TITLE
Add support for AWS ISO-E and ISO-F partitions

### DIFF
--- a/ecr-login/api/client.go
+++ b/ecr-login/api/client.go
@@ -37,7 +37,7 @@ const (
 	ecrPublicEndpoint   = proxyEndpointScheme + ecrPublicName
 )
 
-var ecrPattern = regexp.MustCompile(`^(\d{12})\.dkr\.ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(\.cn)?|sc2s\.sgov\.gov|c2s\.ic\.gov)$`)
+var ecrPattern = regexp.MustCompile(`^(\d{12})\.dkr\.ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(\.cn)?|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
 
 type Service string
 

--- a/ecr-login/api/client_test.go
+++ b/ecr-login/api/client_test.go
@@ -79,6 +79,33 @@ func TestExtractRegistry(t *testing.T) {
 		},
 		hasError: false,
 	}, {
+		serverURL: "123456789012.dkr.ecr.us-isob-east-1.sc2s.sgov.gov",
+		registry: &Registry{
+			ID:      "123456789012",
+			FIPS:    false,
+			Region:  "us-isob-east-1",
+			Service: ServiceECR,
+		},
+		hasError: false,
+	}, {
+		serverURL: "123456789012.dkr.ecr.eu-isoe-west-1.cloud.adc-e.uk",
+		registry: &Registry{
+			ID:      "123456789012",
+			FIPS:    false,
+			Region:  "eu-isoe-west-1",
+			Service: ServiceECR,
+		},
+		hasError: false,
+	}, {
+		serverURL: "123456789012.dkr.ecr.us-isof-east-1.csp.hci.ic.gov",
+		registry: &Registry{
+			ID:      "123456789012",
+			FIPS:    false,
+			Region:  "us-isof-east-1",
+			Service: ServiceECR,
+		},
+		hasError: false,
+	}, {
 		serverURL: "123456789012.dkr.ecr-fips.us-gov-west-1.amazonaws.com",
 		registry: &Registry{
 			ID:      "123456789012",


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This change expands the ECR pattern to allow for the new ISO-E and ISO-F partitions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
