### PR TITLE
Add label workflow to CI

### DIFF
--- a/.github/new-pull-request-labels.yml
+++ b/.github/new-pull-request-labels.yml
@@ -1,0 +1,23 @@
+aws_partition_change:
+  - changed-files:
+      - any-glob-to-any-file: ['ecr-login/vendor/github.com/aws/aws-sdk-go-v2/internal/endpoints/awsrulesfn/partitions.*']
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file: ['**/go.mod', '**/go.sum']
+
+documentation:
+  - changed-files:
+      - all-globs-to-all-files: ['**/*.md']
+
+github_actions:
+  - changed-files:
+      - any-glob-to-any-file: ['.github/**', 'scripts/**']
+
+go:
+  - changed-files:
+      - any-glob-to-any-file: ['**/*.go']
+
+testing:
+  - changed-files:
+      - any-glob-to-any-file: ['integration/**', '**/*_test.go']

--- a/.github/workflows/new-pull-requests.yml
+++ b/.github/workflows/new-pull-requests.yml
@@ -1,0 +1,27 @@
+name: "New Pull Requests"
+
+on:
+  # It is safe to use pull_request_target here because we are not checking out
+  # code from the pull request branch.
+  #
+  # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request_target:
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-22.04
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      # Use label configuration from main instead of from the pull request branch
+      # to mitigate running untrusted workflows with write permissions.
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: '.github/new-pull-request-labels.yml'
+          sync-labels: true


### PR DESCRIPTION
*Issue #, if available:*

As a maintainer, it can be difficult to monitor AWS Go v2 SDK changes for new AWS partition launches.

*Description of changes:*
This change adds label automation to CI to append information to pull requests relative to the changes made. For AWS Go v2 SDK changes with AWS endpoint partition changes, the label `aws_partition_change` will be added to the pull request to signal to maintainers to cross check if a ECR pattern update is required.

Other useful labels include:
- `github_actions` to signal maintainers change to CI/CD and risk mitigation for pwn requests.
- `documentation` to signal change is documentation only.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
