### PR TITLE
Add Go 1.22 to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        go: ['1.19', '1.20', '1.21']
+        go: ['1.21', '1.22']
 
         # Intentionally use specific versions instead of "latest" to
         # make this build reproducible.

--- a/ecr-login/go.mod
+++ b/ecr-login/go.mod
@@ -1,6 +1,6 @@
 module github.com/awslabs/amazon-ecr-credential-helper/ecr-login
 
-go 1.19
+go 1.21
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.3


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This change adds Go 1.22 to CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
