### PR TITLE
Merge release/v0.7 and staging into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 * Enhancement - Updated ECR pattern to match C2S environments. ([#433](https://github.com/awslabs/amazon-ecr-credential-helper/issues/433))
 * Feature (Experimental) - Added support for building Windows ARM credential helper binaries. ([#795](https://github.com/awslabs/amazon-ecr-credential-helper/issues/795))
 
+# 0.7.1
+
+**Note: v0.7.1 is functionally equivalent to v0.7.0. We have decided to create a duplicate release to reflect a more accurate changelog, since our v0.7.0 release did not contain
+any direct/indirect security patches.**
+
+* Feature - Allow callers to set log output. ([#309](https://github.com/awslabs/amazon-ecr-credential-helper/pull/309) and [#312](https://github.com/awslabs/amazon-ecr-credential-helper/pull/312))
+* Upgrade dependencies for bug fixes.
+  
 # 0.7.0
 
 * Feature - Allow callers to set log output. ([#309](https://github.com/awslabs/amazon-ecr-credential-helper/pull/309) and [#312](https://github.com/awslabs/amazon-ecr-credential-helper/pull/312))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The releases for v0.7.1 and v0.8.0 were not fully merged into main. In the case of v0.7.1, the only change was the changelog, so it wasn't merged at all. In the case of v0.8.0, the change was merged either by rebase or squash so the commit ID changed which means the tag for v0.8.0 doesn't point to a commit in main.

This fully merges these branches so that main is fully in sync and going forward we can push to staging from main for releases. 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
