### PR TITLE
Update GitHub Actions runner to macOS 13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
 
         # Intentionally use specific versions instead of "latest" to
         # make this build reproducible.
-        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
+        os: ['ubuntu-22.04', 'macos-13', 'windows-2022']
 
       # Build all variants regardless of failures
       fail-fast: false


### PR DESCRIPTION
*Issue #, if available:*

Resolves warnings in CI for deprecated runner
> A brownout will take place on November 11, 14:00 UTC - November 12, 00:00 UTC to raise awareness of the upcoming macOS-12 environment removal. For more details, see https://github.com/actions/runner-images/issues/10721

*Description of changes:*
This change updates the macOS GitHub action runner used in CI to macOS 13.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
