### PR TITLE
fix: invalid url link in packaging.md

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -18,7 +18,7 @@ the following operating systems:
 * Mac OS X (with the Homebrew package manager)
   ([source](https://github.com/Homebrew/homebrew-core/blob/master/Formula/d/docker-credential-helper-ecr.rb))
 * NixOS (and the Nix package manager)
-  ([source](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/admin/amazon-ecr-credential-helper/default.nix))
+  ([source](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/am/amazon-ecr-credential-helper/package.nix))
 * Arch Linux (in the Arch User Repository)
   ([source](https://aur.archlinux.org/packages/amazon-ecr-credential-helper))
 


### PR DESCRIPTION
*Issue #, if available:*
One of the [CI action runs](https://github.com/awslabs/amazon-ecr-credential-helper/actions/runs/12417094152/job/34834914714?pr=909) is failing due to a invalid link in docs/packaging.md 

*Description of changes:*
Update the doc to point to the new location in nixOS 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
