### PR TITLE
build(deps): drop golang 1.21

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        go: ['1.21', '1.22']
+        go: ['1.22', '1.23']
 
         # Intentionally use specific versions instead of "latest" to
         # make this build reproducible.

--- a/ecr-login/go.mod
+++ b/ecr-login/go.mod
@@ -1,6 +1,6 @@
 module github.com/awslabs/amazon-ecr-credential-helper/ecr-login
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.34.0


### PR DESCRIPTION
*Issue #, if available:* #925

*Description of changes:*
- Drops support for golang 1.21 since it is now unmaintained

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
