### PR TITLE
Add support for custom registry mappings from JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,11 +306,12 @@ The credentials must have a policy applied that
 
 ### Amazon ECR Docker Credential Helper
 
-| Environment Variable         | Sample Value  | Description                                                        |
-| ---------------------------- | ------------- | ------------------------------------------------------------------ |
-| AWS_ECR_DISABLE_CACHE        | true          | Disables the local file auth cache if set to a non-empty value     |
-| AWS_ECR_CACHE_DIR            | ~/.ecr        | Specifies the local file auth cache directory location             |
-| AWS_ECR_IGNORE_CREDS_STORAGE | true          | Ignore calls to docker login or logout and pretend they succeeded  |
+| Environment Variable         | Sample Value       | Description                                                        |
+| ---------------------------- | ------------------ | ------------------------------------------------------------------ |
+| AWS_ECR_DISABLE_CACHE        | true               | Disables the local file auth cache if set to a non-empty value     |
+| AWS_ECR_CACHE_DIR            | ~/.ecr             | Specifies the local file auth cache directory location             |
+| AWS_ECR_IGNORE_CREDS_STORAGE | true               | Ignore calls to docker login or logout and pretend they succeeded  |
+| AWS_ECR_CUSTOM_MAP_PATH      | ~/.ecr/custom.json | Path to custom registry mappings configuration file                |
 
 ## Usage
 

--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -109,7 +109,11 @@ func (self ECRHelper) Delete(serverURL string) error {
 
 func loadCustomMappings() (map[string]string, error) {
 	mappings := make(map[string]string)
-	data, err := os.ReadFile("custom.json")
+	configPath := os.Getenv("AWS_ECR_CUSTOM_MAP_PATH")
+	if configPath == "" {
+		configPath = "custom.json"
+	}
+	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return mappings, nil

--- a/ecr-login/ecr_test.go
+++ b/ecr-login/ecr_test.go
@@ -224,12 +224,18 @@ func TestDeleteNotImplemented(t *testing.T) {
 
 func TestCustomMapping(t *testing.T) {
 	// Create temporary custom.json
+	tmpFile, err := os.CreateTemp("", "custom*.json")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
 	content := []byte(`{
 		"docker.io": "123456789012.dkr.ecr.us-west-2.amazonaws.com"
 	}`)
-	err := os.WriteFile("custom.json", content, 0644)
+	err = os.WriteFile(tmpFile.Name(), content, 0644)
 	assert.NoError(t, err)
-	defer os.Remove("custom.json")
+
+	// Set environment variable to use temp file
+	t.Setenv("AWS_ECR_CUSTOM_MAP_PATH", tmpFile.Name())
 
 	factory := &mock_api.MockClientFactory{}
 	client := &mock_api.MockClient{}


### PR DESCRIPTION
*Issue #, if available:* #947

*Description of changes:*

Adds support for checking the current working directory for `custom.json` for a map of custom registries to ECR registries for auth.

Example `custom.json`:
```json
{
  "docker.io": "402177810328.dkr.ecr.af-south-1.amazonaws.com",
  "ghcr.io": "402177810328.dkr.ecr.af-south-1.amazonaws.com"
}
```

Results in:
```bash
$ echo "docker.io" | ./docker-credential-ecr-login get
{"ServerURL":"docker.io","Username":"AWS","Secret":"redacted"}
$ cat ~/.ecr/log/ecr-login.log                                                                          
time="2025-02-14T19:56:54+02:00" level=debug msg="Using custom registry mapping" mapped=402177810328.dkr.ecr.af-south-1.amazonaws.com original=docker.io
time="2025-02-14T19:56:55+02:00" level=debug msg="Retrieving credentials" region=af-south-1 registry=402177810328 serverURL=402177810328.dkr.ecr.af-south-1.amazonaws.com service=ecr
time="2025-02-14T19:56:55+02:00" level=debug msg="Checking file cache" registry=402177810328
time="2025-02-14T19:56:55+02:00" level=debug msg="Calling ECR.GetAuthorizationToken" registry=402177810328
time="2025-02-14T19:56:55+02:00" level=debug msg="Saving credentials to file cache" registry=402177810328 service=ecr
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

**A note to any reviewers**:
Please be as pedantic as you want. My Go is quite rusty, it's been quite a while since I've written it, I am open to any/all suggestions.
