### PR TITLE
fix: file permissions for ecr-login

### DIFF
--- a/ecr-login/config/log.go
+++ b/ecr-login/config/log.go
@@ -39,7 +39,7 @@ func logrusConfig() {
 		fmt.Fprintf(os.Stderr, "log: failed to create directory: %v", err)
 		logdir = os.TempDir()
 	}
-	file, err := os.OpenFile(filepath.Join(logdir, "ecr-login.log"), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0664)
+	file, err := os.OpenFile(filepath.Join(logdir, "ecr-login.log"), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
*Issue #, if available:*
File permissions for ecr-login.log

*Description of changes:*
Changed permissions to 0644


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
