### PR TITLE
Update ECR endpoint regex for IPv6 endpoint suppport in China regions

### DIFF
--- a/ecr-login/api/client.go
+++ b/ecr-login/api/client.go
@@ -37,7 +37,7 @@ const (
 	ecrPublicEndpoint   = proxyEndpointScheme + ecrPublicName
 )
 
-var ecrPattern = regexp.MustCompile(`^(\d{12})\.dkr[-.]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(on\.aws|amazonaws\.com(\.cn)?|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
+var ecrPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(?:\.cn)?|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
 
 type Service string
 

--- a/ecr-login/api/client_test.go
+++ b/ecr-login/api/client_test.go
@@ -60,17 +60,38 @@ func TestExtractRegistry(t *testing.T) {
 			Service: ServiceECR,
 		},
 		hasError: false,
-        }, {
-                serverURL: "123456789012.dkr-ecr.us-west-2.on.aws",
-                registry: &Registry{
-                        ID:      "123456789012",
-                        FIPS:    false,
-                        Region:  "us-west-2",
-                        Service: ServiceECR,
-                },
-                hasError: false,
+	}, {
+		// Dual-stack endpoint
+		serverURL: "123456789012.dkr-ecr.us-west-2.on.aws",
+		registry: &Registry{
+			ID:      "123456789012",
+			FIPS:    false,
+			Region:  "us-west-2",
+			Service: ServiceECR,
+		},
+		hasError: false,
+	}, {
+		// Dual-stack FIPS endpoint
+		serverURL: "123456789012.dkr-ecr-fips.us-west-2.on.aws",
+		registry: &Registry{
+			ID:      "123456789012",
+			FIPS:    true,
+			Region:  "us-west-2",
+			Service: ServiceECR,
+		},
+		hasError: false,
 	}, {
 		serverURL: "210987654321.dkr.ecr.cn-north-1.amazonaws.com.cn/foo",
+		registry: &Registry{
+			ID:      "210987654321",
+			FIPS:    false,
+			Region:  "cn-north-1",
+			Service: ServiceECR,
+		},
+		hasError: false,
+	}, {
+		// IPv6 CN
+		serverURL: "210987654321.dkr.ecr.cn-north-1.on.amazonwebservices.com.cn",
 		registry: &Registry{
 			ID:      "210987654321",
 			FIPS:    false,
@@ -115,11 +136,31 @@ func TestExtractRegistry(t *testing.T) {
 		},
 		hasError: false,
 	}, {
+		// IPv6 GovCloud
+		serverURL: "123456789012.dkr-ecr.us-gov-east-1.on.aws",
+		registry: &Registry{
+			ID:      "123456789012",
+			FIPS:    false,
+			Region:  "us-gov-east-1",
+			Service: ServiceECR,
+		},
+		hasError: false,
+	}, {
 		serverURL: "123456789012.dkr.ecr-fips.us-gov-west-1.amazonaws.com",
 		registry: &Registry{
 			ID:      "123456789012",
 			FIPS:    true,
 			Region:  "us-gov-west-1",
+			Service: ServiceECR,
+		},
+		hasError: false,
+	}, {
+		// IPv6 GovCloud FIPS
+		serverURL: "123456789012.dkr-ecr-fips.us-gov-east-1.on.aws",
+		registry: &Registry{
+			ID:      "123456789012",
+			FIPS:    true,
+			Region:  "us-gov-east-1",
 			Service: ServiceECR,
 		},
 		hasError: false,
@@ -155,6 +196,10 @@ func TestExtractRegistry(t *testing.T) {
 		hasError:  true,
 	}, {
 		serverURL: "210987654321.dkr.ecr.cn-north-1.amazonaws.com.cn.fake.example.com.cn",
+		hasError:  true,
+	}, {
+		// China region IPv6 endpoints are "on.amazonwebservices.com.cn"
+		serverURL: "210987654321.dkr.ecr.cn-north-1.on.aws.com.cn",
 		hasError:  true,
 	}, {
 		serverURL: "https://public.ecr.aws.fake.example.com",


### PR DESCRIPTION
*Issue #, if available:*
#967 

*Description of changes:*
This change updates the endpoint regex for IPv6 endpoints in China regions.

Reference: https://docs.aws.amazon.com/general/latest/gr/ecr.html#ecr_region

This also aligns the regular expression with https://github.com/kubernetes/cloud-provider-aws/commit/cef3b8fb3cd49e9a13edf4983cdb07c6104b8067

Adds more test cases for IPv6 endpoints. e.g. fips, govcloud, govcloud fips, and cn regions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
