### PR TITLE
chore: update spec file to version 0.10.2-1

### DIFF
--- a/amazon-ecr-credential-helper.spec
+++ b/amazon-ecr-credential-helper.spec
@@ -15,7 +15,7 @@
 %define debug_package %{nil}
 %endif
 Name:           amazon-ecr-credential-helper
-Version:        0.10.1
+Version:        0.10.2
 Release:        1%{?dist}
 Group:          Development/Tools
 Vendor:         Amazon.com
@@ -26,7 +26,7 @@ BuildRoot:      ${_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 Source0: release.tar.gz
 
-BuildRequires: golang >= 1.23.10
+BuildRequires: golang >= 1.24.7
 
 # The following 'Provides' lists the vendored dependencies bundled in
 # and used to produce the amazon-ecr-credential-helper package. As dependencies
@@ -139,6 +139,16 @@ install -D -m 0644 \
 rm -rf %{buildroot}
 
 %changelog
+* Thu Sep 25 2025 swpnlg <swpnlg@amazon.com> - 0.10.2-1
+- Update to v0.10.2
+- Update to v0.10.2
+- Remediate CVE-2025-4673 and CVE-2025-22874
+
+* Thu Sep 25 2025 swpnlg <swpnlg@amazon.com> - 0.10.2-1
+- Update to v0.10.2
+- Updated to v0.10.2
+- Remediate CVE-2025-4673 and CVE-2025-22874
+
 * Tue Jul 1 2025 Arjun Raja Yogidas <arjunry@amazon.com> - 0.10.1-1
 - Update to v0.10.1
 - fix CVE-2025-0913 and CVE-2025-4673


### PR DESCRIPTION
This PR updates the amazon-ecr-credential-helper.spec file to version 0.10.2-1.

Changelog:
- - Update to v0.10.2
- - Remediate CVE-2025-4673 and CVE-2025-22874
