### PR TITLE
chore: update spec file to version 0.10.1-3

### DIFF
--- a/amazon-ecr-credential-helper.spec
+++ b/amazon-ecr-credential-helper.spec
@@ -16,7 +16,7 @@
 %endif
 Name:           amazon-ecr-credential-helper
 Version:        0.10.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Group:          Development/Tools
 Vendor:         Amazon.com
 License:        Apache 2.0
@@ -26,7 +26,7 @@ BuildRoot:      ${_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 Source0: release.tar.gz
 
-BuildRequires: golang >= 1.24.7
+BuildRequires: golang >= 1.24.9
 
 # The following 'Provides' lists the vendored dependencies bundled in
 # and used to produce the amazon-ecr-credential-helper package. As dependencies
@@ -139,6 +139,9 @@ install -D -m 0644 \
 rm -rf %{buildroot}
 
 %changelog
+* Mon Nov 03 2025 davbson <davbson@amazon.com> - 0.10.1-3
+- Rebuild with Golang 1.24.9
+
 * Thu Sep 25 2025 Swapnanil Gupta <swpnlg@amazon.com> - 0.10.1-2
 - Update golang version
 * Tue Jul 1 2025 Arjun Raja Yogidas <arjunry@amazon.com> - 0.10.1-1


### PR DESCRIPTION
This PR updates the amazon-ecr-credential-helper.spec file to version 0.10.1-3.

Changelog:
- Rebuild with Golang 1.24.9
