### PR TITLE
ci: update OS runners to latest versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
 
         # Intentionally use specific versions instead of "latest" to
         # make this build reproducible.
-        os: ['ubuntu-22.04', 'macos-13', 'windows-2022']
+        os: ['ubuntu-24.04', 'macos-15', 'windows-2025']
 
       # Build all variants regardless of failures
       fail-fast: false


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
MacOS13 runners are doing scheduled brownouts now ([example](https://github.com/awslabs/amazon-ecr-credential-helper/actions/runs/19280267553)), so decided to update all of our CI to the latest OS for each platform.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
