### PR TITLE
Propagate context.Context through ECR credential helper

### DIFF
--- a/ecr-login/api/client.go
+++ b/ecr-login/api/client.go
@@ -87,9 +87,9 @@ func ExtractRegistry(input string) (*Registry, error) {
 
 // Client used for calling ECR service
 type Client interface {
-	GetCredentials(serverURL string) (*Auth, error)
-	GetCredentialsByRegistryID(registryID string) (*Auth, error)
-	ListCredentials() ([]*Auth, error)
+	GetCredentials(ctx context.Context, serverURL string) (*Auth, error)
+	GetCredentialsByRegistryID(ctx context.Context, registryID string) (*Auth, error)
+	ListCredentials(ctx context.Context) ([]*Auth, error)
 }
 
 // Auth credentials returned by ECR service to allow docker login
@@ -164,7 +164,7 @@ func (w *ecrPublicClientWrapper) GetAuthorizationToken(ctx context.Context, inpu
 }
 
 // GetCredentials returns username, password, and proxyEndpoint
-func (c *defaultClient) GetCredentials(serverURL string) (*Auth, error) {
+func (c *defaultClient) GetCredentials(ctx context.Context, serverURL string) (*Auth, error) {
 	registry, err := ExtractRegistry(serverURL)
 	if err != nil {
 		return nil, err
@@ -178,15 +178,15 @@ func (c *defaultClient) GetCredentials(serverURL string) (*Auth, error) {
 		Debug("Retrieving credentials")
 	switch registry.Service {
 	case ServiceECR:
-		return c.GetCredentialsByRegistryID(registry.ID)
+		return c.GetCredentialsByRegistryID(ctx, registry.ID)
 	case ServiceECRPublic:
-		return c.GetPublicCredentials(registry.Name)
+		return c.GetPublicCredentials(ctx, registry.Name)
 	}
 	return nil, fmt.Errorf("unknown service %q", registry.Service)
 }
 
 // GetCredentialsByRegistryID returns username, password, and proxyEndpoint
-func (c *defaultClient) GetCredentialsByRegistryID(registryID string) (*Auth, error) {
+func (c *defaultClient) GetCredentialsByRegistryID(ctx context.Context, registryID string) (*Auth, error) {
 	cachedEntry := c.credentialCache.Get(registryID)
 	if cachedEntry != nil {
 		if cachedEntry.IsValid(time.Now()) {
@@ -199,7 +199,7 @@ func (c *defaultClient) GetCredentialsByRegistryID(registryID string) (*Auth, er
 			Debug("Cached token is no longer valid")
 	}
 
-	auth, err := c.getAuthorizationToken(registryID)
+	auth, err := c.getAuthorizationToken(ctx, registryID)
 
 	// if we have a cached token, fall back to avoid failing the request. This may result an expired token
 	// being returned, but if there is a 500 or timeout from the service side, we'd like to attempt to re-use an
@@ -211,7 +211,7 @@ func (c *defaultClient) GetCredentialsByRegistryID(registryID string) (*Auth, er
 	return auth, err
 }
 
-func (c *defaultClient) GetPublicCredentials(registry string) (*Auth, error) {
+func (c *defaultClient) GetPublicCredentials(ctx context.Context, registry string) (*Auth, error) {
 	cachedEntry := c.credentialCache.GetPublic()
 	if cachedEntry != nil {
 		if cachedEntry.IsValid(time.Now()) {
@@ -224,7 +224,7 @@ func (c *defaultClient) GetPublicCredentials(registry string) (*Auth, error) {
 			Debug("Cached token is no longer valid")
 	}
 
-	auth, err := c.getPublicAuthorizationToken(registry)
+	auth, err := c.getPublicAuthorizationToken(ctx, registry)
 	// if we have a cached token, fall back to avoid failing the request. This may result an expired token
 	// being returned, but if there is a 500 or timeout from the service side, we'd like to attempt to re-use an
 	// old token. We invalidate tokens prior to their expiration date to help mitigate this scenario.
@@ -235,13 +235,13 @@ func (c *defaultClient) GetPublicCredentials(registry string) (*Auth, error) {
 	return auth, err
 }
 
-func (c *defaultClient) ListCredentials() ([]*Auth, error) {
+func (c *defaultClient) ListCredentials(ctx context.Context) ([]*Auth, error) {
 	// prime the cache with default authorization tokens
-	_, err := c.GetCredentialsByRegistryID("")
+	_, err := c.GetCredentialsByRegistryID(ctx, "")
 	if err != nil {
 		logrus.WithError(err).Debug("couldn't get authorization token for default registry")
 	}
-	_, err = c.GetPublicCredentials(ecrPublicName)
+	_, err = c.GetPublicCredentials(ctx, ecrPublicName)
 	if err != nil {
 		logrus.WithError(err).Debug("couldn't get authorization token for public registry")
 	}
@@ -259,7 +259,7 @@ func (c *defaultClient) ListCredentials() ([]*Auth, error) {
 	return auths, nil
 }
 
-func (c *defaultClient) getAuthorizationToken(registryID string) (*Auth, error) {
+func (c *defaultClient) getAuthorizationToken(ctx context.Context, registryID string) (*Auth, error) {
 	var input *ecr.GetAuthorizationTokenInput
 	if registryID == "" {
 		logrus.Debug("Calling ECR.GetAuthorizationToken for default registry")
@@ -271,7 +271,7 @@ func (c *defaultClient) getAuthorizationToken(registryID string) (*Auth, error) 
 		}
 	}
 
-	output, err := c.ecrClient.GetAuthorizationToken(context.TODO(), input)
+	output, err := c.ecrClient.GetAuthorizationToken(ctx, input)
 	if err != nil || output == nil {
 		if err == nil {
 			if registryID == "" {
@@ -310,10 +310,10 @@ func (c *defaultClient) getAuthorizationToken(registryID string) (*Auth, error) 
 	return nil, fmt.Errorf("No AuthorizationToken found for %s", registryID)
 }
 
-func (c *defaultClient) getPublicAuthorizationToken(registry string) (*Auth, error) {
+func (c *defaultClient) getPublicAuthorizationToken(ctx context.Context, registry string) (*Auth, error) {
 	var input *ecrpublic.GetAuthorizationTokenInput
 
-	output, err := c.ecrPublicClient.GetAuthorizationToken(context.TODO(), input)
+	output, err := c.ecrPublicClient.GetAuthorizationToken(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("ecr: failed to get authorization token: %w", err)
 	}

--- a/ecr-login/api/client_test.go
+++ b/ecr-login/api/client_test.go
@@ -18,11 +18,15 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
@@ -291,7 +295,7 @@ func TestGetAuthConfigSuccess(t *testing.T) {
 		compareAuthEntry(t, actual, authEntry)
 	}
 
-	auth, err := client.GetCredentials(proxyEndpoint)
+	auth, err := client.GetCredentials(context.Background(), proxyEndpoint)
 	assert.Nil(t, err)
 	assert.Equal(t, auth.Username, expectedUsername)
 	assert.Equal(t, auth.Password, expectedPassword)
@@ -320,7 +324,7 @@ func TestGetAuthConfigNoMatchAuthorizationToken(t *testing.T) {
 
 	credentialCache.GetFn = func(_ string) *cache.AuthEntry { return nil }
 
-	auth, err := client.GetCredentials(proxyEndpoint)
+	auth, err := client.GetCredentials(context.Background(), proxyEndpoint)
 	assert.NotNil(t, err)
 	assert.Nil(t, auth)
 }
@@ -349,7 +353,7 @@ func TestGetAuthConfigGetCacheSuccess(t *testing.T) {
 		return authEntry
 	}
 
-	auth, err := client.GetCredentials(proxyEndpoint)
+	auth, err := client.GetCredentials(context.Background(), proxyEndpoint)
 	assert.Nil(t, err)
 	assert.Equal(t, auth.Username, expectedUsername)
 	assert.Equal(t, auth.Password, expectedPassword)
@@ -403,7 +407,7 @@ func TestGetAuthConfigSuccessInvalidCacheHit(t *testing.T) {
 		compareAuthEntry(t, actual, authEntry)
 	}
 
-	auth, err := client.GetCredentials(proxyEndpoint)
+	auth, err := client.GetCredentials(context.Background(), proxyEndpoint)
 	assert.Nil(t, err)
 	assert.Equal(t, auth.Username, expectedUsername)
 	assert.Equal(t, auth.Password, expectedPassword)
@@ -432,7 +436,7 @@ func TestGetAuthConfigBadBase64(t *testing.T) {
 
 	credentialCache.GetFn = func(_ string) *cache.AuthEntry { return nil }
 
-	auth, err := client.GetCredentials(proxyEndpoint)
+	auth, err := client.GetCredentials(context.Background(), proxyEndpoint)
 	assert.NotNil(t, err)
 	t.Log(err)
 	assert.Nil(t, auth)
@@ -455,7 +459,7 @@ func TestGetAuthConfigMissingResponse(t *testing.T) {
 
 	credentialCache.GetFn = func(_ string) *cache.AuthEntry { return nil }
 
-	auth, err := client.GetCredentials(proxyEndpoint)
+	auth, err := client.GetCredentials(context.Background(), proxyEndpoint)
 	assert.NotNil(t, err)
 	t.Log(err)
 	assert.Nil(t, auth)
@@ -478,7 +482,7 @@ func TestGetAuthConfigECRError(t *testing.T) {
 
 	credentialCache.GetFn = func(_ string) *cache.AuthEntry { return nil }
 
-	auth, err := client.GetCredentials(proxyEndpoint)
+	auth, err := client.GetCredentials(context.Background(), proxyEndpoint)
 	assert.NotNil(t, err)
 	t.Log(err)
 	assert.Nil(t, auth)
@@ -514,7 +518,7 @@ func TestGetAuthConfigSuccessInvalidCacheHitFallback(t *testing.T) {
 		return expiredAuthEntry
 	}
 
-	auth, err := client.GetCredentials(proxyEndpoint)
+	auth, err := client.GetCredentials(context.Background(), proxyEndpoint)
 	assert.Nil(t, err)
 	assert.Equal(t, auth.Username, expectedUsername)
 	assert.Equal(t, auth.Password, expectedPassword)
@@ -554,7 +558,7 @@ func TestListCredentialsSuccess(t *testing.T) {
 	credentialCache.GetPublicFn = func() *cache.AuthEntry { return nil }
 	credentialCache.ListFn = func() []*cache.AuthEntry { return authEntries }
 
-	auths, err := client.ListCredentials()
+	auths, err := client.ListCredentials(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, auths)
 	assert.Len(t, auths, 1)
@@ -596,7 +600,7 @@ func TestListCredentialsCached(t *testing.T) {
 	credentialCache.GetPublicFn = func() *cache.AuthEntry { return authEntry2 }
 	credentialCache.ListFn = func() []*cache.AuthEntry { return authEntries }
 
-	auths, err := client.ListCredentials()
+	auths, err := client.ListCredentials(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, auths)
 	assert.Len(t, auths, 2)
@@ -667,7 +671,7 @@ func TestListCredentialsEmpty(t *testing.T) {
 		setCallCount++
 	}
 
-	auths, err := client.ListCredentials()
+	auths, err := client.ListCredentials(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, auths)
 	assert.Len(t, auths, 2)
@@ -715,7 +719,7 @@ func TestListCredentialsBadBase64AuthToken(t *testing.T) {
 		return nil, errors.New("test error")
 	}
 
-	auths, err := client.ListCredentials()
+	auths, err := client.ListCredentials(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, auths)
 	assert.Empty(t, auths)
@@ -755,7 +759,7 @@ func TestListCredentialsInvalidAuthToken(t *testing.T) {
 		return nil, errors.New("test error")
 	}
 
-	auths, err := client.ListCredentials()
+	auths, err := client.ListCredentials(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, auths)
 	assert.Empty(t, auths)
@@ -952,5 +956,98 @@ func TestECRPublicClientWrapper(t *testing.T) {
 		_, err := client.GetAuthorizationToken(context.Background(), &ecrpublic.GetAuthorizationTokenInput{})
 
 		assert.NoError(t, err)
+	})
+}
+
+func TestContextCancel(t *testing.T) {
+	// Start an HTTP server that accepts connections but never responds,
+	// simulating a hanging endpoint for both credential retrieval and
+	// ECR API calls.
+	testDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-testDone:
+		}
+	}))
+	defer server.Close()
+	defer close(testDone)
+
+	// setupEnv directs the SDK's credential chain to the test server
+	// and disables all other credential sources.
+	setupEnv := func(t *testing.T) {
+		t.Helper()
+		t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", server.URL+"/creds")
+		t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+		t.Setenv("AWS_CONFIG_FILE", os.DevNull)
+		t.Setenv("AWS_SHARED_CREDENTIALS_FILE", os.DevNull)
+		t.Setenv("AWS_ACCESS_KEY_ID", "")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	}
+
+	factory := DefaultClientFactory{}
+
+	// Each subtest creates a client via a different factory method and
+	// verifies that a cancelled context is respected. The context is
+	// pre-cancelled so behaviour is deterministic — BuildCredentialsCache
+	// calls Retrieve(ctx) eagerly, so a live context would block on the
+	// hanging server.
+
+	t.Run("NewClientFromRegion", func(t *testing.T) {
+		setupEnv(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		client, err := factory.NewClientFromRegion(ctx, "us-east-1")
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		auth, err := client.GetCredentials(ctx, proxyEndpoint)
+		assert.Nil(t, auth)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("NewClientWithFipsEndpoint", func(t *testing.T) {
+		setupEnv(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		client, err := factory.NewClientWithFipsEndpoint(ctx, "us-east-1")
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		auth, err := client.GetCredentials(ctx, proxyEndpoint)
+		assert.Nil(t, auth)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("NewClientWithDefaults", func(t *testing.T) {
+		setupEnv(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		client, err := factory.NewClientWithDefaults(ctx)
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		auth, err := client.GetCredentials(ctx, proxyEndpoint)
+		assert.Nil(t, auth)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("GetCredentials", func(t *testing.T) {
+		awsCfg := aws.Config{
+			Region:      "us-east-1",
+			Credentials: awscreds.NewStaticCredentialsProvider("AKID", "SECRET", "TOKEN"),
+		}
+		ecrClient := ecr.NewFromConfig(awsCfg, func(o *ecr.Options) {
+			o.BaseEndpoint = aws.String(server.URL)
+		})
+		credentialCache := &mock_cache.MockCredentialsCache{
+			GetFn: func(_ string) *cache.AuthEntry { return nil },
+		}
+		client := &defaultClient{
+			ecrClient:       ecrClient,
+			credentialCache: credentialCache,
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		auth, err := client.GetCredentials(ctx, proxyEndpoint)
+		assert.Nil(t, auth)
+		assert.ErrorIs(t, err, context.Canceled)
 	})
 }

--- a/ecr-login/api/factory.go
+++ b/ecr-login/api/factory.go
@@ -15,6 +15,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -34,11 +35,11 @@ type Options struct {
 
 // ClientFactory is a factory for creating clients to interact with ECR
 type ClientFactory interface {
-	NewClient(awsConfig aws.Config) Client
-	NewClientWithOptions(opts Options) Client
-	NewClientFromRegion(region string) Client
-	NewClientWithFipsEndpoint(region string) (Client, error)
-	NewClientWithDefaults() Client
+	NewClient(ctx context.Context, awsConfig aws.Config) (Client, error)
+	NewClientWithOptions(ctx context.Context, opts Options) (Client, error)
+	NewClientFromRegion(ctx context.Context, region string) (Client, error)
+	NewClientWithFipsEndpoint(ctx context.Context, region string) (Client, error)
+	NewClientWithDefaults(ctx context.Context) (Client, error)
 }
 
 // DefaultClientFactory is a default implementation of the ClientFactory
@@ -49,59 +50,59 @@ var userAgentLoadOption = config.WithAPIOptions([]func(*middleware.Stack) error{
 })
 
 // NewClientWithDefaults creates the client and defaults region
-func (defaultClientFactory DefaultClientFactory) NewClientWithDefaults() Client {
-	awsConfig, err := config.LoadDefaultConfig(context.TODO(), userAgentLoadOption)
+func (defaultClientFactory DefaultClientFactory) NewClientWithDefaults(ctx context.Context) (Client, error) {
+	awsConfig, err := config.LoadDefaultConfig(ctx, userAgentLoadOption)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("loading default AWS config: %w", err)
 	}
 
-	return defaultClientFactory.NewClientWithOptions(Options{Config: awsConfig})
+	return defaultClientFactory.NewClientWithOptions(ctx, Options{Config: awsConfig})
 }
 
 // NewClientWithFipsEndpoint overrides the default ECR service endpoint in a given region to use the FIPS endpoint
-func (defaultClientFactory DefaultClientFactory) NewClientWithFipsEndpoint(region string) (Client, error) {
+func (defaultClientFactory DefaultClientFactory) NewClientWithFipsEndpoint(ctx context.Context, region string) (Client, error) {
 	awsConfig, err := config.LoadDefaultConfig(
-		context.TODO(),
+		ctx,
 		userAgentLoadOption,
 		config.WithRegion(region),
 		config.WithEndpointDiscovery(aws.EndpointDiscoveryEnabled),
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("loading AWS config for FIPS endpoint in %s: %w", region, err)
 	}
 
-	return defaultClientFactory.NewClientWithOptions(Options{Config: awsConfig}), nil
+	return defaultClientFactory.NewClientWithOptions(ctx, Options{Config: awsConfig})
 }
 
 // NewClientFromRegion uses the region to create the client
-func (defaultClientFactory DefaultClientFactory) NewClientFromRegion(region string) Client {
+func (defaultClientFactory DefaultClientFactory) NewClientFromRegion(ctx context.Context, region string) (Client, error) {
 	awsConfig, err := config.LoadDefaultConfig(
-		context.TODO(),
+		ctx,
 		userAgentLoadOption,
 		config.WithRegion(region),
 	)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("loading AWS config for %s: %w", region, err)
 	}
 
-	return defaultClientFactory.NewClientWithOptions(Options{
+	return defaultClientFactory.NewClientWithOptions(ctx, Options{
 		Config: awsConfig,
 	})
 }
 
 // NewClient Create new client with AWS Config
-func (defaultClientFactory DefaultClientFactory) NewClient(awsConfig aws.Config) Client {
-	return defaultClientFactory.NewClientWithOptions(Options{Config: awsConfig})
+func (defaultClientFactory DefaultClientFactory) NewClient(ctx context.Context, awsConfig aws.Config) (Client, error) {
+	return defaultClientFactory.NewClientWithOptions(ctx, Options{Config: awsConfig})
 }
 
 // NewClientWithOptions Create new client with Options
-func (defaultClientFactory DefaultClientFactory) NewClientWithOptions(opts Options) Client {
+func (defaultClientFactory DefaultClientFactory) NewClientWithOptions(ctx context.Context, opts Options) (Client, error) {
 	// The ECR Public API is only available in us-east-1 today
 	publicConfig := opts.Config.Copy()
 	publicConfig.Region = "us-east-1"
 	return &defaultClient{
 		ecrClient:       NewECRClientWrapper(ecr.NewFromConfig(opts.Config)),
 		ecrPublicClient: NewECRPublicClientWrapper(ecrpublic.NewFromConfig(publicConfig)),
-		credentialCache: cache.BuildCredentialsCache(opts.Config, opts.CacheDir),
-	}
+		credentialCache: cache.BuildCredentialsCache(ctx, opts.Config, opts.CacheDir),
+	}, nil
 }

--- a/ecr-login/cache/build.go
+++ b/ecr-login/cache/build.go
@@ -29,7 +29,7 @@ import (
 	ecrconfig "github.com/awslabs/amazon-ecr-credential-helper/ecr-login/config"
 )
 
-func BuildCredentialsCache(config aws.Config, cacheDir string) CredentialsCache {
+func BuildCredentialsCache(ctx context.Context, config aws.Config, cacheDir string) CredentialsCache {
 	if os.Getenv("AWS_ECR_DISABLE_CACHE") != "" {
 		logrus.Debug("Cache disabled due to AWS_ECR_DISABLE_CACHE")
 		return NewNullCredentialsCache()
@@ -48,7 +48,7 @@ func BuildCredentialsCache(config aws.Config, cacheDir string) CredentialsCache 
 
 	cacheFilename := "cache.json"
 
-	credentials, err := config.Credentials.Retrieve(context.TODO())
+	credentials, err := config.Credentials.Retrieve(ctx)
 	if err != nil {
 		logrus.WithError(err).Debug("Could not fetch credentials for cache prefix, disabling cache")
 		return NewNullCredentialsCache()

--- a/ecr-login/cache/build_test.go
+++ b/ecr-login/cache/build_test.go
@@ -14,6 +14,7 @@
 package cache
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -41,7 +42,7 @@ func TestFactoryBuildFileCache(t *testing.T) {
 		Credentials: credentials.NewStaticCredentialsProvider(testAccessKey, testSecretKey, testToken),
 	}
 
-	cache := BuildCredentialsCache(config, "")
+	cache := BuildCredentialsCache(context.Background(), config, "")
 	assert.NotNil(t, cache)
 
 	fileCache, ok := cache.(*fileCredentialCache)
@@ -57,7 +58,7 @@ func TestFactoryBuildNullCacheWithoutCredentials(t *testing.T) {
 		Credentials: aws.AnonymousCredentials{},
 	}
 
-	cache := BuildCredentialsCache(config, "")
+	cache := BuildCredentialsCache(context.Background(), config, "")
 	assert.NotNil(t, cache)
 
 	_, ok := cache.(*nullCredentialsCache)
@@ -70,7 +71,7 @@ func TestFactoryBuildNullCache(t *testing.T) {
 
 	config := aws.Config{Region: testRegion}
 
-	cache := BuildCredentialsCache(config, "")
+	cache := BuildCredentialsCache(context.Background(), config, "")
 	assert.NotNil(t, cache)
 	_, ok := cache.(*nullCredentialsCache)
 	assert.True(t, ok, "built cache is a nullCredentialsCache")
@@ -133,7 +134,7 @@ func TestLegacyKeysNotGeneratedInFipsSimulation(t *testing.T) {
 		Credentials: credentials.NewStaticCredentialsProvider(testAccessKey, testSecretKey, testToken),
 	}
 
-	cache := BuildCredentialsCache(config, "")
+	cache := BuildCredentialsCache(context.Background(), config, "")
 	assert.NotNil(t, cache)
 
 	fileCache, ok := cache.(*fileCredentialCache)

--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -14,6 +14,7 @@
 package ecr
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -29,6 +30,9 @@ import (
 var notImplemented = errors.New("not implemented")
 
 type ECRHelper struct {
+	// ctx is stored because the credentials.Helper interface methods
+	// do not accept a context parameter.
+	ctx context.Context
 	clientFactory api.ClientFactory
 	logger        *logrus.Logger
 }
@@ -56,10 +60,18 @@ func WithLogger(w io.Writer) Option {
 	}
 }
 
+// WithContext sets the context used for network calls made by the helper.
+func WithContext(ctx context.Context) Option {
+	return func(e *ECRHelper) {
+		e.ctx = ctx
+	}
+}
+
 // NewECRHelper returns a new ECRHelper with the given options to override
 // default behavior.
 func NewECRHelper(opts ...Option) *ECRHelper {
 	e := &ECRHelper{
+		ctx:           context.Background(),
 		clientFactory: api.DefaultClientFactory{},
 		logger:        logrus.StandardLogger(),
 	}
@@ -119,16 +131,16 @@ func (self ECRHelper) Get(serverURL string) (string, string, error) {
 
 	var client api.Client
 	if registry.FIPS {
-		client, err = self.clientFactory.NewClientWithFipsEndpoint(registry.Region)
-		if err != nil {
-			self.logger.WithError(err).Error("Error resolving FIPS endpoint")
-			return "", "", credentials.NewErrCredentialsNotFound()
-		}
+		client, err = self.clientFactory.NewClientWithFipsEndpoint(self.ctx, registry.Region)
 	} else {
-		client = self.clientFactory.NewClientFromRegion(registry.Region)
+		client, err = self.clientFactory.NewClientFromRegion(self.ctx, registry.Region)
+	}
+	if err != nil {
+		self.logger.WithError(err).Error("Error creating ECR client")
+		return "", "", credentials.NewErrCredentialsNotFound()
 	}
 
-	auth, err := client.GetCredentials(serverURL)
+	auth, err := client.GetCredentials(self.ctx, serverURL)
 	if err != nil {
 		self.logger.WithError(err).Error("Error retrieving credentials")
 		return "", "", credentials.NewErrCredentialsNotFound()
@@ -138,9 +150,13 @@ func (self ECRHelper) Get(serverURL string) (string, string, error) {
 
 func (self ECRHelper) List() (map[string]string, error) {
 	self.logger.Debug("Listing credentials")
-	client := self.clientFactory.NewClientWithDefaults()
+	client, err := self.clientFactory.NewClientWithDefaults(self.ctx)
+	if err != nil {
+		self.logger.WithError(err).Error("Error creating ECR client")
+		return nil, fmt.Errorf("ecr: could not create client: %v", err)
+	}
 
-	auths, err := client.ListCredentials()
+	auths, err := client.ListCredentials(self.ctx)
 	if err != nil {
 		self.logger.WithError(err).Error("Error listing credentials")
 		return nil, fmt.Errorf("ecr: could not list credentials: %v", err)

--- a/ecr-login/ecr_test.go
+++ b/ecr-login/ecr_test.go
@@ -14,6 +14,7 @@
 package ecr
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -61,8 +62,8 @@ func TestGetSuccess(t *testing.T) {
 
 	helper := NewECRHelper(WithClientFactory(factory))
 
-	factory.NewClientFromRegionFn = func(_ string) ecr.Client { return client }
-	client.GetCredentialsFn = func(serverURL string) (*ecr.Auth, error) {
+	factory.NewClientFromRegionFn = func(_ context.Context, _ string) (ecr.Client, error) { return client, nil }
+	client.GetCredentialsFn = func(_ context.Context, serverURL string) (*ecr.Auth, error) {
 		if serverURL != proxyEndpoint {
 			return nil, fmt.Errorf("unexpected input: %s", serverURL)
 		}
@@ -85,8 +86,8 @@ func TestGetError(t *testing.T) {
 
 	helper := NewECRHelper(WithClientFactory(factory))
 
-	factory.NewClientFromRegionFn = func(_ string) ecr.Client { return client }
-	client.GetCredentialsFn = func(serverURL string) (*ecr.Auth, error) {
+	factory.NewClientFromRegionFn = func(_ context.Context, _ string) (ecr.Client, error) { return client, nil }
+	client.GetCredentialsFn = func(_ context.Context, serverURL string) (*ecr.Auth, error) {
 		return nil, errors.New("test error")
 	}
 
@@ -111,8 +112,8 @@ func TestListSuccess(t *testing.T) {
 
 	helper := NewECRHelper(WithClientFactory(factory))
 
-	factory.NewClientWithDefaultsFn = func() ecr.Client { return client }
-	client.ListCredentialsFn = func() ([]*ecr.Auth, error) {
+	factory.NewClientWithDefaultsFn = func(_ context.Context) (ecr.Client, error) { return client, nil }
+	client.ListCredentialsFn = func(_ context.Context) ([]*ecr.Auth, error) {
 		return []*ecr.Auth{{
 			Username:      expectedUsername,
 			Password:      expectedPassword,
@@ -132,8 +133,8 @@ func TestListFailure(t *testing.T) {
 
 	helper := NewECRHelper(WithClientFactory(factory))
 
-	factory.NewClientWithDefaultsFn = func() ecr.Client { return client }
-	client.ListCredentialsFn = func() ([]*ecr.Auth, error) {
+	factory.NewClientWithDefaultsFn = func(_ context.Context) (ecr.Client, error) { return client, nil }
+	client.ListCredentialsFn = func(_ context.Context) ([]*ecr.Auth, error) {
 		return nil, errors.New("nope")
 	}
 
@@ -221,3 +222,85 @@ func TestDeleteNotImplemented(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPropagatesContext(t *testing.T) {
+	factory := &mock_api.MockClientFactory{}
+	client := &mock_api.MockClient{}
+
+	ctx := context.WithValue(context.Background(), contextKey("test"), "value")
+	helper := NewECRHelper(WithClientFactory(factory), WithContext(ctx))
+
+	factory.NewClientFromRegionFn = func(gotCtx context.Context, _ string) (ecr.Client, error) {
+		assert.Equal(t, ctx, gotCtx, "factory should receive the context from WithContext")
+		return client, nil
+	}
+	client.GetCredentialsFn = func(gotCtx context.Context, serverURL string) (*ecr.Auth, error) {
+		assert.Equal(t, ctx, gotCtx, "client should receive the context from WithContext")
+		return &ecr.Auth{
+			Username:      expectedUsername,
+			Password:      expectedPassword,
+			ProxyEndpoint: proxyEndpointUrl,
+		}, nil
+	}
+
+	username, password, err := helper.Get(proxyEndpoint)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedUsername, username)
+	assert.Equal(t, expectedPassword, password)
+}
+
+func TestGetFipsPropagatesContext(t *testing.T) {
+	factory := &mock_api.MockClientFactory{}
+	client := &mock_api.MockClient{}
+
+	ctx := context.WithValue(context.Background(), contextKey("test"), "fips")
+	helper := NewECRHelper(WithClientFactory(factory), WithContext(ctx))
+
+	fipsEndpoint := "123456789012.dkr.ecr-fips.us-gov-west-1.amazonaws.com"
+
+	factory.NewClientWithFipsEndpointFn = func(gotCtx context.Context, _ string) (ecr.Client, error) {
+		assert.Equal(t, ctx, gotCtx, "factory should receive the context from WithContext")
+		return client, nil
+	}
+	client.GetCredentialsFn = func(gotCtx context.Context, _ string) (*ecr.Auth, error) {
+		assert.Equal(t, ctx, gotCtx, "client should receive the context from WithContext")
+		return &ecr.Auth{
+			Username:      expectedUsername,
+			Password:      expectedPassword,
+			ProxyEndpoint: "https://" + fipsEndpoint,
+		}, nil
+	}
+
+	username, password, err := helper.Get(fipsEndpoint)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedUsername, username)
+	assert.Equal(t, expectedPassword, password)
+}
+
+func TestListPropagatesContext(t *testing.T) {
+	factory := &mock_api.MockClientFactory{}
+	client := &mock_api.MockClient{}
+
+	ctx := context.WithValue(context.Background(), contextKey("test"), "value")
+	helper := NewECRHelper(WithClientFactory(factory), WithContext(ctx))
+
+	factory.NewClientWithDefaultsFn = func(gotCtx context.Context) (ecr.Client, error) {
+		assert.Equal(t, ctx, gotCtx, "factory should receive the context from WithContext")
+		return client, nil
+	}
+	client.ListCredentialsFn = func(gotCtx context.Context) ([]*ecr.Auth, error) {
+		assert.Equal(t, ctx, gotCtx, "client should receive the context from WithContext")
+		return []*ecr.Auth{{
+			Username:      expectedUsername,
+			Password:      expectedPassword,
+			ProxyEndpoint: proxyEndpointUrl,
+		}}, nil
+	}
+
+	serverList, err := helper.List()
+	assert.NoError(t, err)
+	assert.Len(t, serverList, 1)
+}
+
+// contextKey is a private type for context keys in tests to avoid collisions.
+type contextKey string

--- a/ecr-login/mocks/ecr_mocks.go
+++ b/ecr-login/mocks/ecr_mocks.go
@@ -14,56 +14,58 @@
 package mock_api
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api"
 )
 
 type MockClientFactory struct {
-	NewClientFn                 func(awsConfig aws.Config) api.Client
-	NewClientWithOptionsFn      func(opts api.Options) api.Client
-	NewClientFromRegionFn       func(region string) api.Client
-	NewClientWithFipsEndpointFn func(region string) (api.Client, error)
-	NewClientWithDefaultsFn     func() api.Client
+	NewClientFn                 func(ctx context.Context, awsConfig aws.Config) (api.Client, error)
+	NewClientWithOptionsFn      func(ctx context.Context, opts api.Options) (api.Client, error)
+	NewClientFromRegionFn       func(ctx context.Context, region string) (api.Client, error)
+	NewClientWithFipsEndpointFn func(ctx context.Context, region string) (api.Client, error)
+	NewClientWithDefaultsFn     func(ctx context.Context) (api.Client, error)
 }
 
-func (m MockClientFactory) NewClient(awsConfig aws.Config) api.Client {
-	return m.NewClientFn(awsConfig)
+func (m MockClientFactory) NewClient(ctx context.Context, awsConfig aws.Config) (api.Client, error) {
+	return m.NewClientFn(ctx, awsConfig)
 }
 
-func (m MockClientFactory) NewClientWithOptions(opts api.Options) api.Client {
-	return m.NewClientWithOptionsFn(opts)
+func (m MockClientFactory) NewClientWithOptions(ctx context.Context, opts api.Options) (api.Client, error) {
+	return m.NewClientWithOptionsFn(ctx, opts)
 }
 
-func (m MockClientFactory) NewClientFromRegion(region string) api.Client {
-	return m.NewClientFromRegionFn(region)
+func (m MockClientFactory) NewClientFromRegion(ctx context.Context, region string) (api.Client, error) {
+	return m.NewClientFromRegionFn(ctx, region)
 }
 
-func (m MockClientFactory) NewClientWithFipsEndpoint(region string) (api.Client, error) {
-	return m.NewClientWithFipsEndpointFn(region)
+func (m MockClientFactory) NewClientWithFipsEndpoint(ctx context.Context, region string) (api.Client, error) {
+	return m.NewClientWithFipsEndpointFn(ctx, region)
 }
 
-func (m MockClientFactory) NewClientWithDefaults() api.Client {
-	return m.NewClientWithDefaultsFn()
+func (m MockClientFactory) NewClientWithDefaults(ctx context.Context) (api.Client, error) {
+	return m.NewClientWithDefaultsFn(ctx)
 }
 
 var _ api.ClientFactory = (*MockClientFactory)(nil)
 
 type MockClient struct {
-	GetCredentialsFn             func(serverURL string) (*api.Auth, error)
-	GetCredentialsByRegistryIDFn func(registryID string) (*api.Auth, error)
-	ListCredentialsFn            func() ([]*api.Auth, error)
+	GetCredentialsFn             func(ctx context.Context, serverURL string) (*api.Auth, error)
+	GetCredentialsByRegistryIDFn func(ctx context.Context, registryID string) (*api.Auth, error)
+	ListCredentialsFn            func(ctx context.Context) ([]*api.Auth, error)
 }
 
 var _ api.Client = (*MockClient)(nil)
 
-func (m *MockClient) GetCredentials(serverURL string) (*api.Auth, error) {
-	return m.GetCredentialsFn(serverURL)
+func (m *MockClient) GetCredentials(ctx context.Context, serverURL string) (*api.Auth, error) {
+	return m.GetCredentialsFn(ctx, serverURL)
 }
 
-func (m *MockClient) GetCredentialsByRegistryID(registryID string) (*api.Auth, error) {
-	return m.GetCredentialsByRegistryIDFn(registryID)
+func (m *MockClient) GetCredentialsByRegistryID(ctx context.Context, registryID string) (*api.Auth, error) {
+	return m.GetCredentialsByRegistryIDFn(ctx, registryID)
 }
 
-func (m *MockClient) ListCredentials() ([]*api.Auth, error) {
-	return m.ListCredentialsFn()
+func (m *MockClient) ListCredentials(ctx context.Context) ([]*api.Auth, error) {
+	return m.ListCredentialsFn(ctx)
 }


### PR DESCRIPTION

## Summary

- Add `WithContext(ctx)` option to `NewECRHelper()` that propagates a caller-supplied `context.Context` through all internal layers (factory, client, cache) to the actual AWS SDK calls
- Replace all 6 `context.TODO()` call sites with the propagated context, making ECR operations cancellable and deadline-aware
- Default to `context.Background()` when `WithContext` is not used, preserving existing behavior

## Motivation

This change was prompted by difficulties encountered in [knative/func#3864](https://github.com/knative/func/pull/3864), where the ECR credential helper's use of `context.TODO()` made it impossible to cancel or time out hanging network requests. When AWS SDK calls (config loading, `GetAuthorizationToken`, credential retrieval) stall, the caller has no way to interrupt them because the context is hardcoded.

The `credentials.Helper` interface from `docker-credential-helpers` has fixed method signatures with no context parameter, so the context is stored in the `ECRHelper` struct and passed internally.


## Breaking changes

The `Client`, `ClientFactory` interfaces and `BuildCredentialsCache` function now require a `context.Context` first parameter. External consumers of these APIs will need to update call sites.

However I believe most people use the API at the `credentials.Helper` level.

## Note on panic in factory methods

`NewClientWithDefaults` and `NewClientFromRegion` call `config.LoadDefaultConfig(ctx, ...)` and `panic` on error, while `NewClientWithFipsEndpoint` properly returns the error to the caller. This was a latent issue before this change — with `context.TODO()`, `LoadDefaultConfig` could only fail due to malformed config files or missing credential providers, which are arguably unrecoverable. But now that we pass a real context, `LoadDefaultConfig` can also fail for a routine, expected reason: context cancellation. It makes network calls (IMDS for region/credential discovery, STS for token exchange, etc.) that all respect the context. A caller that sets a short deadline via `WithContext` will get a `panic` instead of a graceful error if e.g. IMDS is slow. Note that this is a non-issue for default usage — without `WithContext`, the helper uses `context.Background()` which is never cancelled, preserving the existing behavior. The panic can only be triggered when a caller explicitly opts in to a cancellable context.

Two possible follow-up fixes:

1. **Return `(Client, error)` from all factory methods** — align `NewClientWithDefaults` and `NewClientFromRegion` with `NewClientWithFipsEndpoint`, which already returns an error. This is the smaller change since the `ClientFactory` interface is already being modified in this PR, but it pushes error handling to every call site.

2. **Lazy config loading** — defer `LoadDefaultConfig` until the first API call (`GetCredentials`, `ListCredentials`), where the error can be returned through the existing `error` return value. Factory methods would just capture parameters and the `defaultClient` would load config on first use (via `sync.Once` or similar). This keeps construction infallible and avoids further interface changes, at the cost of added internal complexity.
