### PR TITLE
fix: use the AccountID in when generating the cred cache prefix

### DIFF
--- a/ecr-login/cache/build.go
+++ b/ecr-login/cache/build.go
@@ -71,23 +71,23 @@ func BuildCredentialsCache(ctx context.Context, config aws.Config, cacheDir stri
 	)
 }
 
-// Determine a key prefix for a credentials cache. Because auth tokens are scoped to an account and region, rely on provided
-// region, as well as hash of the access key.
+// Determine a key prefix for a credentials cache. Because auth tokens are scoped to an account and region, rely on the
+// provided region and a hash of the AWS account ID.
 func credentialsCachePrefix(region string, credentials aws.Credentials) string {
-	return fmt.Sprintf("%s-%s-", region, checksum(credentials.AccessKeyID))
+	return fmt.Sprintf("%s-%s-", region, checksum(credentials.AccountID))
 }
 
 func credentialsPublicCacheKey(credentials aws.Credentials) string {
-	return fmt.Sprintf("%s-%s", ServiceECRPublic, checksum(credentials.AccessKeyID))
+	return fmt.Sprintf("%s-%s", ServiceECRPublic, checksum(credentials.AccountID))
 }
 
 // Legacy cache key functions for backward compatibility with MD5-based keys
 func legacyCredentialsCachePrefix(region string, credentials aws.Credentials) string {
-	return fmt.Sprintf("%s-%s-", region, md5Checksum(credentials.AccessKeyID))
+	return fmt.Sprintf("%s-%s-", region, md5Checksum(credentials.AccountID))
 }
 
 func legacyCredentialsPublicCacheKey(credentials aws.Credentials) string {
-	return fmt.Sprintf("%s-%s", ServiceECRPublic, md5Checksum(credentials.AccessKeyID))
+	return fmt.Sprintf("%s-%s", ServiceECRPublic, md5Checksum(credentials.AccountID))
 }
 
 // Base64 encodes a SHA-256 checksum. Used for uniqueness, not cryptographic security.

--- a/ecr-login/cache/build_test.go
+++ b/ecr-login/cache/build_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,16 +29,28 @@ const (
 	testAccessKey     = "accessKey"
 	testSecretKey     = "secretKey"
 	testToken         = "token"
-	// base64 SHA-256 sum of "accessKey" - FIPS-compatible
-	testCredentialHash = "xOV45/s/9aT8cbO8tDicjEV1KKkfpLdKrQs0ipPGgGc="
-	// Legacy base64 MD5 sum of "accessKey" for backward compatibility tests
-	testLegacyCredentialHash = "YWNjZXNzS2V51B2M2Y8AsgTpgAmY7PhCfg=="
+	testAccountID     = "123456789012"
+	// base64 SHA-256 sum of "accountID" - FIPS-compatible
+	testCredentialHash = "KjM0nn5gaorS4w48hFIfk3dFDPCQg+Fi4KmxSAzg+XI="
+	// Legacy base64 MD5 sum of "accountID" for backward compatibility tests
+	testLegacyCredentialHash = "MTIzNDU2Nzg5MDEy1B2M2Y8AsgTpgAmY7PhCfg=="
 )
+
+func testCredentialsProvider() aws.CredentialsProvider {
+	return aws.CredentialsProviderFunc(func(context.Context) (aws.Credentials, error) {
+		return aws.Credentials{
+			AccessKeyID:     testAccessKey,
+			SecretAccessKey: testSecretKey,
+			SessionToken:    testToken,
+			AccountID:       testAccountID,
+		}, nil
+	})
+}
 
 func TestFactoryBuildFileCache(t *testing.T) {
 	config := aws.Config{
 		Region:      testRegion,
-		Credentials: credentials.NewStaticCredentialsProvider(testAccessKey, testSecretKey, testToken),
+		Credentials: testCredentialsProvider(),
 	}
 
 	cache := BuildCredentialsCache(context.Background(), config, "")
@@ -79,7 +90,7 @@ func TestFactoryBuildNullCache(t *testing.T) {
 
 // TestCredentialsPrefixUsesNewHash verifies that credentialsCachePrefix uses SHA-256
 func TestCredentialsPrefixUsesNewHash(t *testing.T) {
-	creds := aws.Credentials{AccessKeyID: testAccessKey}
+	creds := aws.Credentials{AccountID: testAccountID}
 	prefix := credentialsCachePrefix(testRegion, creds)
 	expectedPrefix := fmt.Sprintf("%s-%s-", testRegion, testCredentialHash)
 
@@ -131,7 +142,7 @@ func TestIsFipsMode(t *testing.T) {
 func TestLegacyKeysNotGeneratedInFipsSimulation(t *testing.T) {
 	config := aws.Config{
 		Region:      testRegion,
-		Credentials: credentials.NewStaticCredentialsProvider(testAccessKey, testSecretKey, testToken),
+		Credentials: testCredentialsProvider(),
 	}
 
 	cache := BuildCredentialsCache(context.Background(), config, "")


### PR DESCRIPTION
*Issue #, if available: https://github.com/awslabs/amazon-ecr-credential-helper/issues/1107

*Description of changes: Use the AccountID in when generating the cred cache prefix instead of the instead the AccessKeyID which often changes if the AWS prinicpal is a role (leading to not getting a cache hit).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
